### PR TITLE
Problem: fty-autoconfig cannot find the templates directory.

### DIFF
--- a/src/agents/autoconfig/fty-autoconfig.cc
+++ b/src/agents/autoconfig/fty-autoconfig.cc
@@ -40,7 +40,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 using namespace persist;
 
 const char* Autoconfig::StateFilePath = "/var/lib/bios/agent-autoconfig";
-const char* Autoconfig::RuleFilePath = "/usr/share/bios/agent-autoconfig";
+const char* Autoconfig::RuleFilePath = "/usr/share/bios/fty-autoconfig";
 const char* Autoconfig::StateFile = "/var/lib/bios/agent-autoconfig/state";
 
 static int


### PR DESCRIPTION
Solution: Change the path.

Signed-off-by: Jana Rapava <janarapava@eaton.com>