### PR TITLE
Problem: some services does not work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -99,10 +99,6 @@ var/
 build/
 build-*/
 
-fty-rest-*.*/
-fty-rest-*.*.tar.?z
-fty-rest-*.deb
-
 src/utils/messages/json_schemas.h
 tools/bios-passwd
 !tools/bios-passwd.in

--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # autoconf/automake basis
 AC_PREREQ([2.5])
-AC_INIT([fty-rest], [0.1.0], [EatonIPCOpensource@Eaton.com])
+AC_INIT([bios], [0.1.0], [EatonIPCOpensource@Eaton.com])
 PACKAGE_VENDOR="Eaton"
 
 AC_CONFIG_MACRO_DIR([m4])
@@ -14,7 +14,7 @@ AM_INIT_AUTOMAKE([foreign 1.11 -Wall -Wno-portability silent-rules tar-pax no-di
 LT_PREREQ([2.2])
 LT_INIT([disable-static])
 
-AS_IF([test "x$enable_static" = "xyes"], [AC_MSG_ERROR([--enable-static is not supported by 42ITy fty-rest])])
+AS_IF([test "x$enable_static" = "xyes"], [AC_MSG_ERROR([--enable-static is not supported by BIOS core])])
 
 AC_ARG_WITH([package-vendor],
 	[AS_HELP_STRING([--with-package-vendor=ARG],


### PR DESCRIPTION
Solution: use old names, it's not that easy to fix it
Revert "configure.ac / .gitignore : this repo is now fty-rest"

This reverts commit 6ad70b1dd4bb38fcf77f75605d2299a85b53138d.