### PR TITLE
Problem: REST API call input_power_chain expects DB ID as an argument.

### DIFF
--- a/src/web/src/input_power_chain.ecpp
+++ b/src/web/src/input_power_chain.ecpp
@@ -158,12 +158,7 @@ fill_array_powerchains (std::vector <std::tuple
         http_die ("request-param-bad", dc_id.c_str ());
 
     int rv = -1;
-    int64_t num_dc_id = persist::name_to_asset_id (dc_id);
-  
-    if ( num_dc_id == -1 )
-        http_die ("not-found", "dc_id ", dc_id.c_str ());
-  
-    rv = input_power_group_response (url, num_dc_id, devices_data, powerchains_data);
+    rv = input_power_group_response (url, std::stoi (dc_id), devices_data, powerchains_data);
   
     if (rv == -1)    
     {    


### PR DESCRIPTION
Solution: Conform the code to this assumption.

Signed-off-by: Jana Rapava <JanaRapava@eaton.com>