### PR TITLE
Problem: current REST API call does not support non numeric ids

### DIFF
--- a/src/web/src/current.ecpp
+++ b/src/web/src/current.ecpp
@@ -162,11 +162,10 @@ std::vector<uint32_t> asset_ids;
 
     for ( auto asset_id : foo ) {
         http_errors_t errors;
-        uint32_t id = 0;
 
-        if (!check_element_identifier ("dev", asset_id, id, errors)) {
-            http_die_error (errors);
-        }
+        if ( !is_ok_name (asset_id.c_str ()) )
+            http_die ("request-param-bad", "dev", asset_id.c_str (), "valid asset name");
+        auto id = persist::name_to_asset_id (asset_id);
         asset_ids.push_back(id);
     }
 }


### PR DESCRIPTION
Solution: add a support and translate input parameter to DB id

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>