### PR TITLE
Problem: asset POST do not translate location

### DIFF
--- a/src/db/inout/importcsv.cc
+++ b/src/db/inout/importcsv.cc
@@ -745,7 +745,7 @@ std::pair<db_a_elmnt_t, persist::asset_operation>
     auto SUBTYPES = read_device_types (conn);
 
     std::set<a_elmnt_id_t> ids{};
-    auto ret = process_row(conn, cm, 1, TYPES, SUBTYPES, ids, false);
+    auto ret = process_row(conn, cm, 1, TYPES, SUBTYPES, ids, true);
     LOG_END;
     return ret;
 }


### PR DESCRIPTION
Solution: call process_row with santize=true

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>