### PR TITLE
Problem: can post fully unicode name

### DIFF
--- a/src/db/asset_general.cc
+++ b/src/db/asset_general.cc
@@ -233,7 +233,9 @@ db_reply_t
         return ret;
     }
     setlocale (LC_ALL, ""); // move this to main?
-    char *iname = ic_utf8_to_name ((char *) element_name);
+    char *iname = ic_utf8_to_name (
+            (char *) element_name,
+            persist::typeid_to_type (element_type_id).c_str ());
     log_debug ("  element_name = '%s/%s'", element_name, iname);
 
     tntdb::Transaction trans(conn);
@@ -327,7 +329,9 @@ db_reply_t
         return ret;
     }
     setlocale (LC_ALL, ""); // move this to main?
-    char *iname = ic_utf8_to_name ((char *)element_name);
+    char *iname = ic_utf8_to_name (
+            (char *)element_name,
+            persist::subtypeid_to_subtype (asset_device_type_id).c_str ());
     log_debug ("  element_name = '%s/%s'", element_name, iname);
     
     tntdb::Transaction trans(conn);

--- a/src/shared/ic.c
+++ b/src/shared/ic.c
@@ -24,6 +24,7 @@
 #include <errno.h>
 #include <iconv.h>
 #include <ctype.h>
+#include "ic.h"
 
 static
 int s_convert(iconv_t id, char *inbuf, size_t *bytes, char *outbuf, size_t *capacity)
@@ -96,10 +97,13 @@ char *ic_utf8_to_ascii (char *string)
     return ic_convert (string, strlen (string)+1, "UTF-8", "ASCII//TRANSLIT", NULL);
 }
 
-char *ic_utf8_to_name (char *string)
+char *ic_utf8_to_name (char *string, const char *prefix)
 {
     char *ascii = ic_utf8_to_ascii (string);
-    if (!ascii) return NULL;
+    if (!ascii || strlen (ascii) == 0) {
+        zstr_free (&ascii);
+        return zsys_sprintf ("%s-%d", prefix, time (NULL));
+    }
 
     char *name = (char *) malloc (strlen (ascii) + 1);
     if (!name) {
@@ -134,6 +138,10 @@ char *ic_utf8_to_name (char *string)
     }
     name [j] = '\0';
     free (ascii);
+    if (!name || strlen (name) == 0) {
+        zstr_free (&name);
+        return zsys_sprintf ("%s-%d", prefix, time (NULL));
+    }
     return name;
 }
 

--- a/src/shared/ic.h
+++ b/src/shared/ic.h
@@ -22,7 +22,7 @@
 #ifndef _IC_H_INCLUDED
 #define _IC_H_INCLUDED
 
-#include <stdlib.h>
+#include <czmq.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -49,10 +49,13 @@ char *ic_utf8_to_ascii (char *string);
 // readable but simple and asscii. Output is limited
 // to first 40 characters.
 //
+// if transliteration to ascii returns empty string,
+// use prefix-$unixtime
+//
 // See note about setlocale before.
-// 
+//
 // You have to free returned string yourself
-char *ic_utf8_to_name (char *string);
+char *ic_utf8_to_name (char *string, const char *prefix);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Solution: transliterate returns NULL, but this case is never handled and
empty name is then forbidden. Return prefix-$unixtime in a case
transliteration fails.

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>