### PR TITLE
Problem: asset GET returns wrong error if not found

### DIFF
--- a/src/web/src/asset_GET.ecpp
+++ b/src/web/src/asset_GET.ecpp
@@ -181,7 +181,7 @@ UserInfo user;
             id = type + id;
             http_errors_t errors;
             if (!check_element_identifier ("dev", id, checked_id, errors)) {
-                http_die_error (errors);
+                http_die ("element-not-found", id.c_str ());
             }
         }
     }


### PR DESCRIPTION
Solution: return the correct one

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>