### PR TITLE
Problem: fty-rest does not pass travis distcheck

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -326,7 +326,7 @@ libpriv_csv_la_CPPFLAGS =$(AM_CPPFLAGS) \
 			-I$(abs_top_builddir)/tools \
 			-I$(abs_top_src_dir)/src/msg
 
-libpriv_csv_la_LIBADD = ${CXXTOOLS_LIBS}
+libpriv_csv_la_LIBADD = ${CXXTOOLS_LIBS} -ltntdb
 
 noinst_LTLIBRARIES += 		libpriv-db.la
 
@@ -635,11 +635,11 @@ test_cidr_LDFLAGS =	-lcidr
 check_PROGRAMS += 	test-csv
 
 test_csv_SOURCES =		src/shared/csv.h \
-					    tests/shared/test-csv.cc
+						tests/shared/test-csv.cc
 
 test_csv_LDADD = 		libpriv-csv.la \
 						libpriv-log.la \
-					    libpriv-test-run.la
+						libpriv-test-run.la
 
 test_csv_CPPFLAGS =		$(AM_CPPFLAGS) \
 			-I$(abs_top_srcdir)/src/persist \

--- a/Makefile.am
+++ b/Makefile.am
@@ -267,7 +267,7 @@ libpriv_utils_plusplus_la_SOURCES = \
 				src/shared/filesystem.h \
 				src/shared/filesystem.cc
 
-libpriv_utils_plusplus_la_LIBADD = ${CXXTOOLS_LIBS}
+libpriv_utils_plusplus_la_LIBADD = ${LIBCZMQ_LIBS}
 
 noinst_LTLIBRARIES += 		libpriv-defs.la
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -805,7 +805,7 @@ CLEANFILES += $(cibin_programs_list)
 ### Verification that bios_web.so is in fact usable on binary level
 ### Note that this creates no retainable output file
 web-link-test: bios_web.la
-			@$(CXX) $(AM_CPPFLAGS) $(AM_CXXFLAGS) -o /dev/null \
+			$(CXX) $(AM_CPPFLAGS) $(AM_CXXFLAGS) -o /dev/null \
 			$(abs_top_srcdir)/tests/web-linking-test.cc \
 			${CXXTOOLS_LIBS} -ltntnet \
 			$(abs_top_builddir)/.libs/bios_web.so && \

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ dist_noinst_DATA =
 # A source file listed in BUILT_SOURCES is made on `make all` or `make check`
 # (or even `make install`) before other targets are processed. However, such
 # a source file is not compiled unless explicitly requested by mentioning it
-# in some other _SOURCES variable. 
+# in some other _SOURCES variable.
 BUILT_SOURCES =
 # http://www.gnu.org/software/automake/manual/html_node/Clean.html
 # * If make built it, and it is commonly something that one would want to
@@ -105,7 +105,7 @@ RUN_TNTNET = cat "$(RUN_TNTNET_ENVFILE)" || exit; \
 # tracking (which is automatic), but to ensure these files are
 # distributed by "make dist" although not "installed".
 
-dist_noinst_HEADERS = 
+dist_noinst_HEADERS =
 
 # Clean up products of configure script
 DISTCLEANFILES += \
@@ -552,7 +552,7 @@ test_utils_web_CPPFLAGS = \
 test_utils_web_LDFLAGS =	${CXXTOOLS_LIBS} -lczmq
 
 ###
-check_PROGRAMS +=	test-tntmlm	
+check_PROGRAMS +=	test-tntmlm
 
 test_tntmlm_SOURCES = \
 			src/shared/tntmlm.h \
@@ -571,7 +571,7 @@ test_tntmlm_CPPFLAGS = \
 
 test_tntmlm_LDFLAGS =	${LIBCZMQ_LIBS} ${LIBMLM_LIBS} ${CXXTOOLS_LIBS}
 
-check_PROGRAMS +=	test-utils-plusplus	
+check_PROGRAMS +=	test-utils-plusplus
 
 test_utils_plusplus_SOURCES = \
 			src/shared/utils++.h \
@@ -767,7 +767,7 @@ cibin_programs += 	test-totalpower
 
 test_totalpower_SOURCES = \
 			tests/persist/test-rack-power.cc \
-			tests/persist/test-dc-power.cc 
+			tests/persist/test-dc-power.cc
 
 test_totalpower_LDADD = \
 			libpriv-db.la \
@@ -1158,7 +1158,7 @@ EXTRA_DIST += \
 # and written in asciidoc markup
 # Note these should have paths relative to project root dir.
 BASE_DOCS_ASCIIDOC =	INSTALL \
-			CONTRIBUTING 
+			CONTRIBUTING
 
 # Documentation files saved in the project source-code root directory
 # as text files without extensions in the name and written in plain
@@ -1186,7 +1186,7 @@ TXT_DOCS_PLAINTEXT =
 # (as in case of the _ASCIIDOC list).
 # Filenames here should not have spaces and should have the '.txt' suffix.
 
-MAPPED_TXT_DOCS_PLAINTEXT = 
+MAPPED_TXT_DOCS_PLAINTEXT =
 
 MAPPED_TXT_DOCS_ASCIIDOC = \
 	src/web/README.txt:$(myDEVDOCDIR)/README-web-tests-generalInfo.txt

--- a/Makefile.am
+++ b/Makefile.am
@@ -805,7 +805,7 @@ CLEANFILES += $(cibin_programs_list)
 ### Verification that bios_web.so is in fact usable on binary level
 ### Note that this creates no retainable output file
 web-link-test: bios_web.la
-			$(CXX) $(AM_CPPFLAGS) $(AM_CXXFLAGS) -o /dev/null \
+			$(CXX) $(AM_CPPFLAGS) $(DEFAULT_INCLUDES) $(INCLUDES) $(CPPFLAGS) $(AM_CXXFLAGS) $(CXXFLAGS) -o /dev/null \
 			$(abs_top_srcdir)/tests/web-linking-test.cc \
 			${CXXTOOLS_LIBS} -ltntnet \
 			$(abs_top_builddir)/.libs/bios_web.so && \

--- a/src/db/inout/importcsv.cc
+++ b/src/db/inout/importcsv.cc
@@ -376,7 +376,7 @@ static std::pair<db_a_elmnt_t, persist::asset_operation>
         // if column doesn't exist, then break the cycle
         {
             log_debug ("end of group processing");
-            log_debug (e.what());
+            log_debug ("%s", e.what());
             break;
         }
         log_debug ("group_name = '%s'", group.c_str());
@@ -414,7 +414,7 @@ static std::pair<db_a_elmnt_t, persist::asset_operation>
         // if column doesn't exist, then break the cycle
         {
             log_debug ("end of power links processing");
-            log_debug (e.what());
+            log_debug ("%s", e.what());
             break;
         }
 
@@ -449,7 +449,7 @@ static std::pair<db_a_elmnt_t, persist::asset_operation>
         catch (const std::out_of_range &e)
         {
             log_debug ("'%s' - is missing at all", link_col_name1.c_str());
-            log_debug (e.what());
+            log_debug ("%s", e.what());
         }
 
         // column name
@@ -465,7 +465,7 @@ static std::pair<db_a_elmnt_t, persist::asset_operation>
         catch (const std::out_of_range &e)
         {
             log_debug ("'%s' - is missing at all", link_col_name2.c_str());
-            log_debug (e.what());
+            log_debug ("%s", e.what());
         }
 
         if ( one_link.src != 0 ) // if first column was ok

--- a/src/shared/data.cc
+++ b/src/shared/data.cc
@@ -106,7 +106,7 @@ db_reply <db_web_element_t>
             ret.errtype       = basic_ret.errtype;
             ret.errsubtype    = basic_ret.errsubtype;
             ret.msg           = basic_ret.msg;
-            log_warning (ret.msg.c_str());
+            log_warning ("%s", ret.msg.c_str());
             return ret;
         }
         log_debug ("    1/5 no errors");
@@ -121,7 +121,7 @@ db_reply <db_web_element_t>
             ret.errtype       = ext_ret.errtype;
             ret.errsubtype    = ext_ret.errsubtype;
             ret.msg           = ext_ret.msg;
-            log_warning (ret.msg.c_str());
+            log_warning ("%s", ret.msg.c_str());
             return ret;
         }
         log_debug ("    2/5 no errors");
@@ -136,7 +136,7 @@ db_reply <db_web_element_t>
             ret.errtype       = group_ret.errtype;
             ret.errsubtype    = group_ret.errsubtype;
             ret.msg           = group_ret.msg;
-            log_warning (ret.msg.c_str());
+            log_warning ("%s", ret.msg.c_str());
             return ret;
         }
         log_debug ("    3/5 no errors");
@@ -153,7 +153,7 @@ db_reply <db_web_element_t>
                 ret.errtype       = powers.errtype;
                 ret.errsubtype    = powers.errsubtype;
                 ret.msg           = powers.msg;
-                log_warning (ret.msg.c_str());
+                log_warning ("%s", ret.msg.c_str());
                 return ret;
             }
             log_debug ("    4/5 no errors");
@@ -195,7 +195,7 @@ db_reply <std::map <uint32_t, std::string> >
         ret.errtype       = DB_ERR;
         ret.errsubtype    = DB_ERROR_INTERNAL;
         ret.msg           = "Unsupported type of the elemnts";
-        log_error (ret.msg.c_str());
+        log_error ("%s", ret.msg.c_str());
         // TODO need to have some more precise list of types, so we don't have to change anything here,
         // if something was changed
         bios_error_idx(ret.rowid, ret.msg, "request-param-bad", "type", typeName.c_str(), "datacenters,rooms,ros,racks,devices");
@@ -209,7 +209,7 @@ db_reply <std::map <uint32_t, std::string> >
             ret.errtype       = DB_ERR;
             ret.errsubtype    = DB_ERROR_INTERNAL;
             ret.msg           = "Unsupported subtype of the elemnts";
-            log_error (ret.msg.c_str());
+            log_error ("%s", ret.msg.c_str());
             // TODO need to have some more precise list of types, so we don't have to change anything here,
             // if something was changed
             bios_error_idx(ret.rowid, ret.msg, "request-param-bad", "subtype", subtypeName.c_str(), "ups, epdu, pdu, genset, sts, server, feed");
@@ -262,7 +262,7 @@ db_reply_t
             ret.errtype       = basic_info.errsubtype;
             ret.errsubtype    = DB_ERROR_NOTFOUND;
             ret.msg           = "problem with selecting basic info";
-            log_warning (ret.msg.c_str());
+            log_warning ("%s", ret.msg.c_str());
             return ret;
         }
         // here we are only if everything was ok
@@ -295,7 +295,7 @@ db_reply_t
                 ret.errtype       = basic_info.errsubtype;
                 ret.errsubtype    = DB_ERROR_INTERNAL;
                 ret.msg           = "unknown type";
-                log_warning (ret.msg.c_str());
+                log_warning ("%s", ret.msg.c_str());
             }
         }
         LOG_END;

--- a/src/shared/utils++.cc
+++ b/src/shared/utils++.cc
@@ -157,12 +157,12 @@ std::string sql_escape(const std::string& in) {
 std::map<std::string,std::string> zhash_to_map(zhash_t *hash)
 {
     std::map<std::string,std::string> map;
-    char *item = (char *)zhash_first(hash);
+    char *item = (char *)::zhash_first(hash);
     while(item) {
-        const char * key = zhash_cursor(hash);
-        const char * val = (const char *)zhash_lookup(hash,key);
+        const char * key = ::zhash_cursor(hash);
+        const char * val = (const char *)::zhash_lookup(hash,key);
         if( key && val ) map[key] = val;
-        item = (char *)zhash_next(hash);
+        item = (char *)::zhash_next(hash);
     }
     return map;
 }


### PR DESCRIPTION
Solution: finally root out the bugs in source code and recipes, so travis tests for the repo pass green!

Consequence: from now on, red travis results for fty-rest is by 99% chance the fault of recent committers.