### PR TITLE
Problem: our components use random czmq version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ before_script:
 - ./.travis.fixsasl
 
 # Hand off to generated script for each BUILD_TYPE
-script: ./ci_build.sh
+script: travis_wait 30 ./ci_build.sh
 before_deploy: . ./ci_deploy.sh
 deploy:
   provider: releases

--- a/builds/valgrind/ci_build.sh
+++ b/builds/valgrind/ci_build.sh
@@ -35,7 +35,7 @@ fi
 make -j4
 make install
 cd ..
-git clone --quiet --depth 1 https://github.com/zeromq/czmq.git czmq.git
+git clone --quiet --depth 1 -b v3.0.2 https://github.com/42ity/czmq.git czmq.git
 cd czmq.git
 git --no-pager log --oneline -n1
 if [ -e autogen.sh ]; then

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -256,7 +256,8 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
         BASE_PWD=${PWD}
         echo "`date`: INFO: Building prerequisite 'czmq' from Git repository..." >&2
         # $CI_TIME git clone --quiet --depth 1 -b v3.0.2 https://github.com/zeromq/czmq.git czmq
-        $CI_TIME git clone --quiet --depth 1 https://github.com/42ity/czmq czmq
+        # $CI_TIME git clone --quiet --depth 1 https://github.com/42ity/czmq czmq
+        $CI_TIME git clone --quiet --depth 1 -b v3.0.2 https://github.com/42ity/czmq czmq
         cd czmq
         CCACHE_BASEDIR=${PWD}
         export CCACHE_BASEDIR


### PR DESCRIPTION
Solution: reference our fork of czmq branch v3.0.2 (vanilla + our few patches) in ci_build.sh. Impacts mostly just the consistency of Travis and common 42ity/FTY builds (our components' configure.ac should comply either way).