### PR TITLE
Problem: input_power_chain call accepts  only numerical ids

### DIFF
--- a/src/web/tntnet.xml
+++ b/src/web/tntnet.xml
@@ -356,7 +356,7 @@
     <mapping>
       <target>input_power_chain@bios_web</target>
       <method>GET</method>
-      <url>^/api/v1/topology/input_power_chain/([0-9]+)$</url>
+      <url>^/api/v1/topology/input_power_chain/.*$</url>
       <args>
         <id>$1</id>
       </args>

--- a/src/web/tntnet.xml
+++ b/src/web/tntnet.xml
@@ -356,7 +356,7 @@
     <mapping>
       <target>input_power_chain@bios_web</target>
       <method>GET</method>
-      <url>^/api/v1/topology/input_power_chain/.*$</url>
+      <url>^/api/v1/topology/input_power_chain/(.+)$</url>
       <args>
         <id>$1</id>
       </args>


### PR DESCRIPTION
Solution: characters are allowed too

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>