### PR TITLE
Problem: some clients passes asset name to REST API

### DIFF
--- a/src/web/src/helpers.cc
+++ b/src/web/src/helpers.cc
@@ -52,11 +52,16 @@ iname_to_dbid (const std::string& url, const std::string& asset_name)
         int64_t id = 0;
 
         tntdb::Connection conn = tntdb::connectCached(url);
+        // MVY: This makes sure that passing of asset (display) name will work too
         tntdb::Statement st = conn.prepareCached(
-        " SELECT id_asset_element"
-        " FROM"
-        "   t_bios_asset_element"
-        " WHERE name = :asset_name"
+        " SELECT DISTINCT (asset.id_asset_element) "
+        " FROM "
+        "   t_bios_asset_element AS asset "
+        " LEFT JOIN t_bios_asset_ext_attributes AS ext "
+        " ON "
+        "   asset.id_asset_element = ext.id_asset_element "
+        " WHERE asset.name = :asset_name "
+        " OR (ext.keytag = \"name\" AND ext.value = :asset_name) "
         );
 
         tntdb::Row row = st.set("asset_name", asset_name).selectRow();


### PR DESCRIPTION
Solution: be clever and take a look to ext ["name"] if it does not
match.

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>