### PR TITLE
Problem: we do not use available pkgconfig deps metadata when building fty-rest

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -530,7 +530,7 @@ test_web_helpers_CPPFLAGS =	$(AM_CPPFLAGS) \
 							-I$(abs_top_srcdir)/tests/include/ \
 							-I$(abs_top_srcdir)/src/web/include
 
-test_web_helpers_LDFLAGS =	-ltntnet -ltntdb ${CXXTOOLS_LIBS} $(LIBCZMQ_LIBS)
+test_web_helpers_LDFLAGS =	-ltntnet -ltntdb ${CXXTOOLS_LIBS} ${LIBCZMQ_LIBS}
 
 ###
 check_PROGRAMS +=	test-utils-web
@@ -549,7 +549,7 @@ test_utils_web_CPPFLAGS = \
 			$(AM_CPPFLAGS) \
 			-I$(abs_top_srcdir)/tests/include/
 
-test_utils_web_LDFLAGS =	${CXXTOOLS_LIBS} -lczmq
+test_utils_web_LDFLAGS =	${CXXTOOLS_LIBS} ${LIBCZMQ_LIBS}
 
 ###
 check_PROGRAMS +=	test-tntmlm
@@ -621,7 +621,7 @@ test_subprocess_LDADD = 		libpriv-subprocess.la \
 					libpriv-test-run.la
 test_subprocess_CPPFLAGS =		$(AM_CPPFLAGS) \
 					-I$(abs_top_srcdir)/tests/include/
-test_subprocess_LDFLAGS =		${CXXTOOLS_LIBS} -lczmq
+test_subprocess_LDFLAGS =		${CXXTOOLS_LIBS} ${LIBCZMQ_LIBS}
 
 check_PROGRAMS += 	test-cidr
 test_cidr_SOURCES = 	src/shared/cidr.cc \
@@ -629,7 +629,7 @@ test_cidr_SOURCES = 	src/shared/cidr.cc \
 test_cidr_LDADD = 	libpriv-test-run.la
 test_cidr_CPPFLAGS = 	$(AM_CPPFLAGS) \
 			-I$(abs_top_srcdir)/tests/include/
-test_cidr_LDFLAGS =	-lcidr
+test_cidr_LDFLAGS =	${LIBCIDR_LIBS}
 
 
 check_PROGRAMS += 	test-csv
@@ -704,7 +704,7 @@ test_db2_CPPFLAGS =	$(AM_CPPFLAGS) \
 			-I$(abs_top_srcdir)/src/db \
 			-I$(abs_top_srcdir)/src
 
-test_db2_LDFLAGS =	-ltntdb ${CXXTOOLS_LIBS} -lcidr ${LIBCZMQ_LIBS}
+test_db2_LDFLAGS =	-ltntdb ${CXXTOOLS_LIBS} ${LIBCIDR_LIBS} ${LIBCZMQ_LIBS}
 
 cibin_programs += 	test-dbtopology
 
@@ -732,7 +732,7 @@ test_dbtopology_CPPFLAGS = \
 			-I$(abs_top_builddir)/tools
 
 test_dbtopology_LDFLAGS = \
-			-ltntdb ${CXXTOOLS_LIBS} -lcidr ${LIBCZMQ_LIBS}
+			-ltntdb ${CXXTOOLS_LIBS} ${LIBCIDR_LIBS} ${LIBCZMQ_LIBS}
 
 
 cibin_programs += 	test-db-asset-crud
@@ -759,7 +759,7 @@ test_db_asset_crud_CPPFLAGS = \
 			-I$(abs_top_builddir)/tools
 
 test_db_asset_crud_LDFLAGS = \
-			-ltntdb ${CXXTOOLS_LIBS} -lcidr ${LIBCZMQ_LIBS}
+			-ltntdb ${CXXTOOLS_LIBS} ${LIBCIDR_LIBS} ${LIBCZMQ_LIBS}
 
 
 #### total power tests
@@ -785,7 +785,7 @@ test_totalpower_CPPFLAGS = \
 			-I$(abs_top_builddir)/tools
 
 test_totalpower_LDFLAGS = \
-			-ltntdb ${CXXTOOLS_LIBS} -lcidr ${LIBCZMQ_LIBS}
+			-ltntdb ${CXXTOOLS_LIBS} ${LIBCIDR_LIBS} ${LIBCZMQ_LIBS}
 
 
 # Do we build and install CI programs by default? (see configure)
@@ -847,7 +847,7 @@ bios_csv_LDADD = \
 						 libpriv-utils-plusplus.la \
 						 libpriv-csv.la
 bios_csv_LDFLAGS = \
-						 ${CXXTOOLS_LIBS} -ltntdb $(LIBCZMQ_LIBS)
+						 ${CXXTOOLS_LIBS} -ltntdb ${LIBCZMQ_LIBS}
 
 #XXX: $(localstatedir) did not worked
 #FIXME: installing things to /var is not a good idea according FHS or GNU standards
@@ -896,7 +896,7 @@ warranty_metric_CPPFLAGS =	$(AM_CPPFLAGS) \
 			-I$(abs_top_builddir)/tools \
 			-I$(abs_top_srcdir)/src/db
 
-warranty_metric_LDFLAGS = ${LIBCZMQ_LIBS} ${LIBMLM_LIBS} -ltntdb ${CXXTOOLS_LIBS} -lfty_proto
+warranty_metric_LDFLAGS = ${LIBCZMQ_LIBS} ${LIBMLM_LIBS} -ltntdb ${CXXTOOLS_LIBS} ${LIBFTYPROTO_LIBS}
 
 ###################################################################
 # Web Library (tntnet dynamic module for $BIOS REST API)
@@ -976,11 +976,12 @@ bios_web_la_CPPFLAGS =	$(AM_CPPFLAGS) \
 			-I$(abs_top_srcdir)/src/agents/configure_inform \
 			-I$(abs_top_srcdir)/src/db/assets
 
+# Note: the libmagic we use delivers no pkg-config, so we include it explicitly
 bios_web_la_LDFLAGS = 	${LIBCZMQ_LIBS}	${CXXTOOLS_LIBS} \
 			${LIBSODIUM_LIBS} ${LIBSASL2_LIBS} \
 			${LIBBIOSPROTO_LIBS} \
 			$(LDFLAGS_NO_UNDEFS) \
-			-module -lm -ltntdb -ltntnet -lcidr -lmagic ${LIBMLM_LIBS} -lfty_proto -lz
+			-module -lm -ltntdb -ltntnet ${LIBCIDR_LIBS} -lmagic ${LIBMLM_LIBS} ${LIBFTYPROTO_LIBS} -lz
 
 bios_web_la_LIBADD = \
 			libpriv-db.la libpriv-cidr.la libpriv-proto.la \

--- a/ci_build.sh
+++ b/ci_build.sh
@@ -519,6 +519,7 @@ if [ "$BUILD_TYPE" == "default" ] || [ "$BUILD_TYPE" == "default-Werror" ] || [ 
     # (and it is not our duty to check prerequisite projects anyway)
     CONFIG_OPTS+=("${CONFIG_OPT_WERROR}")
     $CI_TIME ./autogen.sh 2> /dev/null
+    echo "+ ./configure" "${CONFIG_OPTS[@]}"
     $CI_TIME ./configure "${CONFIG_OPTS[@]}"
     if [ "$BUILD_TYPE" == "valgrind" ] ; then
         # Build and check this project

--- a/configure.ac
+++ b/configure.ac
@@ -696,7 +696,7 @@ Summary:
         LIBSASL2_LIBS:           ${LIBSASL2_LIBS}
         LIBMLM_CFLAGS:           ${LIBMLM_CFLAGS}
         LIBMLM_LIBS:             ${LIBMLM_LIBS}
-        LIBFTYPROTO_LIBS:       ${LIBFTYPROTO_LIBS}
+        LIBFTYPROTO_LIBS:        ${LIBFTYPROTO_LIBS}
         SASLAUTHD_MUX:           ${SASLAUTHD_MUX}
         PKG_CONFIG:              ${PKG_CONFIG}
         SYSTEMDSYSTEMUNITDIR:    ${systemdsystemunitdir}

--- a/configure.ac
+++ b/configure.ac
@@ -25,6 +25,7 @@ AC_ARG_WITH([package-vendor],
 	# This may be left empty by explicit request
 )
 
+PKG_PROG_PKG_CONFIG
 # Set pkgconfigdir
 AC_ARG_WITH([pkgconfigdir], AS_HELP_STRING([--with-pkgconfigdir=PATH],
 	[Path to the pkgconfig directory [[LIBDIR/pkgconfig]]]),


### PR DESCRIPTION
Solution: to avoid confusion if there is a choice of same package variants in the system, ensure usage of the one detected during configure.

This is a "low-hanging fruit" subset of original PR #125 which should be safe to merge already (does not require OBS reconfiguration) since this selection only uses pkg-config data we have and detect for ages.