### PR TITLE
PROBLEM: Rule templates missing

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -878,7 +878,10 @@ RULE_TEMPLATES = \
 			src/agents/autoconfig/rule_templates/voltage.input_1phase@__device_epdu__.rule \
 			src/agents/autoconfig/rule_templates/voltage.input_1phase@__device_ups__.rule \
 			src/agents/autoconfig/rule_templates/voltage.input_3phase@__device_epdu__.rule \
-			src/agents/autoconfig/rule_templates/voltage.input_3phase@__device_ups__.rule
+			src/agents/autoconfig/rule_templates/voltage.input_3phase@__device_ups__.rule \
+            src/agents/autoconfig/rule_templates/sts-frequency@__device_sts__.rule \
+            src/agents/autoconfig/rule_templates/sts-preferred-source@__device_sts__.rule \
+            src/agents/autoconfig/rule_templates/sts-voltage@__device_sts__.rule	
 
 template_rule_DATA =	$(RULE_TEMPLATES)
 EXTRA_DIST +=		$(RULE_TEMPLATES)


### PR DESCRIPTION
Rules templates for sts/ats are missing.
They were accidentally removed in this commit
https://github.com/42ity/fty-rest/commit/78ee60d6bb092655b299cf82adf589b22faab134

SOLUTION: Fix it.

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>