### PR TITLE
PROBLEM: Invalid json

### DIFF
--- a/src/agents/autoconfig/rule_templates/sts-voltage@__device_sts__.rule
+++ b/src/agents/autoconfig/rule_templates/sts-voltage@__device_sts__.rule
@@ -3,7 +3,7 @@
     "name"          : "sts-voltage@__name__",
     "description"   : "The voltage is out of tolerance",
     "metrics"       : ["status.input.1.voltage", "status.input.2.voltage"],
-    "assets"         : [__name__],
+    "assets"         : ["__name__"],
     "results"       :  {
         "high_warning"  : { "action" : ["EMAIL"] }
     },


### PR DESCRIPTION
Template for rule sts-voltage had unescaped template placeholder \_\_name\_\_.

BIOS-3463

SOLUTION: Fix it.

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>