### PR TITLE
PROBLEM: rest api call response uses old id

### DIFF
--- a/src/web/src/average.ecpp
+++ b/src/web/src/average.ecpp
@@ -368,7 +368,7 @@ UserInfo user;
         <$$ utils::json::jsonify ("source", source_rep) $>,
         <$$ utils::json::jsonify ("step", step_rep) $>,
         <$$ utils::json::jsonify ("type", type_rep) $>,
-        <$$ utils::json::jsonify ("element_id", std::to_string(checked_element_id)) $>,
+        <$$ utils::json::jsonify ("element_id", element_name) $>,
         <$$ utils::json::jsonify ("start_ts", start_date_rep) $>,
         <$$ utils::json::jsonify ("end_ts", end_date_rep) $>,
         "data":[


### PR DESCRIPTION
`metric/computed/average` rest api call produces response with old
element id.
SOLUTION: Fix it

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>