### PR TITLE
Problem: use of persist::name_to_asset_id() is inconsistent

### DIFF
--- a/src/db/assets/assetr.cc
+++ b/src/db/assets/assetr.cc
@@ -236,7 +236,7 @@ db_reply <db_web_basic_element_t>
         ret.status        = 0;
         ret.errtype       = DB_ERR;
         ret.errsubtype    = DB_ERROR_NOTFOUND;
-        ret.msg           = "element with spesified id was not found";
+        ret.msg           = "element with specified id was not found";
         log_info ("end: %s", ret.msg.c_str());
         return ret;
     }

--- a/src/web/src/alert_list.ecpp
+++ b/src/web/src/alert_list.ecpp
@@ -151,7 +151,14 @@ UserInfo user;
                 state.c_str (), asset.c_str (), recursive.c_str ());
     }
 
-element_id = (uint32_t) persist::name_to_asset_id (checked_asset);
+    {
+        int64_t dbid =  persist::name_to_asset_id (checked_asset);
+        if (dbid == -1) {
+            http_die ("element-not-found", checked_asset.c_str ());
+        }
+
+        element_id = (uint32_t) dbid;
+    }
 
 std::map<std::string, int> desired_elements;
 tntdb::Connection connection;

--- a/src/web/src/asset_DELETE.ecpp
+++ b/src/web/src/asset_DELETE.ecpp
@@ -43,7 +43,7 @@ UserInfo user;
             {BiosProfile::Admin,     "D"}
             };
     CHECK_USER_PERMISSIONS_OR_DIE (PERMISSIONS);
-    std::string checked_id;
+    std::string checked_id; // user-friendly identifier
 
     // sanity check
     {
@@ -63,6 +63,7 @@ UserInfo user;
     if (dbid == -1) {
         http_die ("element-not-found", checked_id.c_str ());
     }
+
     // delete it
     db_a_elmnt_t row;
     auto ret = asset_mgr.delete_item (dbid, row);

--- a/src/web/src/datacenter_indicators.ecpp
+++ b/src/web/src/datacenter_indicators.ecpp
@@ -273,13 +273,15 @@ UserInfo user;
     std::vector<std::string> DCNames;
     std::vector<uint32_t> DCIDs;
     for (auto const& item : DCs) {
-        uint32_t id_num = (uint32_t) persist::name_to_asset_id (item);
-
-        auto it = allDcsShort.item.find (id_num);
+        int64_t dbid =  persist::name_to_asset_id (item);
+        if (dbid == -1) {
+            http_die ("element-not-found", item.c_str ());
+        }
+        auto it = allDcsShort.item.find ((uint32_t) dbid);
         if (it == allDcsShort.item.end()) {
             http_die ("element-not-found", item.c_str ());
         }
-        DCIDs.push_back (id_num);
+        DCIDs.push_back (dbid);
         DCNames.push_back (it->second);
     }
 

--- a/src/web/src/input_power_chain.ecpp
+++ b/src/web/src/input_power_chain.ecpp
@@ -158,12 +158,12 @@ fill_array_powerchains (std::vector <std::tuple
         http_die ("request-param-bad", dc_id.c_str ());
 
     int rv = -1;
-    int64_t num_dc_id = persist::name_to_asset_id (dc_id);
+    int64_t dbid = persist::name_to_asset_id (dc_id);
 
-    if ( num_dc_id == -1 )
+    if ( dbid == -1 )
         http_die ("element-not-found", "dc_id ", dc_id.c_str ());
 
-    rv = input_power_group_response (url, num_dc_id, devices_data, powerchains_data);
+    rv = input_power_group_response (url, dbid, devices_data, powerchains_data);
 
     if (rv == -1)
     {

--- a/src/web/src/rack_total.ecpp
+++ b/src/web/src/rack_total.ecpp
@@ -220,12 +220,15 @@ std::string checked_arg2;
         if ( !is_ok_name (item.c_str ()) )
             http_die ("request-param-bad", "arg2", item.c_str (), "valid asset name");
 
-        auto real_id = persist::name_to_asset_id (item);
-        auto it = allRacksShort.item.find(real_id);
+        auto dbid = persist::name_to_asset_id (item);
+        if (dbid == -1) {
+            http_die ("element-not-found", item.c_str ());
+        }
+        auto it = allRacksShort.item.find(dbid);
         if (it == allRacksShort.item.end()) {
             http_die ("element-not-found", item.c_str ());
         }
-        rackNames.push_back (persist::id_to_name_ext_name (real_id).second);
+        rackNames.push_back (persist::id_to_name_ext_name (dbid).second);
     }
 
     std::stringstream json;

--- a/src/web/src/topology_power.ecpp
+++ b/src/web/src/topology_power.ecpp
@@ -111,10 +111,10 @@ UserInfo user;
             parameter_name = "filter_group";
         }
 
-	if (!is_ok_name (asset_id.c_str ()) )
+        if (!is_ok_name (asset_id.c_str ()) )
             http_die ("request-param-bad", "id", asset_id.c_str (), "valid asset name");
         checked_id = persist::name_to_asset_id (asset_id);
-	if (checked_id == -1)
+        if (checked_id == -1)
             http_die ("request-param-bad", "id", asset_id.c_str (), "existing asset name");
     }
     // Sanity check end


### PR DESCRIPTION
Context: the recently introduced persist::name_to_asset_id() returns an int64_t value which is either "-1" for errors (and/or absent asset), or the uint32_t value of database internal identifier. Some consumers just casted the return value to uint32_t and/or did not check for "-1" returns, and got funny results when the value was actually "-1" for error.
    
Solution: revise existing calls to the function to use int64_t, check for "-1", and use the rest as before. Also make the code look more consistent by naming the value "dbid" in more places (where it causes just little changes in codebase).

Thanks to @kkathreen for pinpointing in the tediously collected logs where exactly things go south.