### PR TITLE
Problem: asset parameter is optional

### DIFF
--- a/src/web/src/alert_list.ecpp
+++ b/src/web/src/alert_list.ecpp
@@ -153,10 +153,9 @@ UserInfo user;
 
     {
         int64_t dbid =  persist::name_to_asset_id (checked_asset);
-        if (dbid == -1) {
+        if (!checked_asset.empty () && dbid == -1) {
             http_die ("element-not-found", checked_asset.c_str ());
         }
-
         element_id = (uint32_t) dbid;
     }
 


### PR DESCRIPTION
Solution: fail only if checked_asset is not empty

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>