### PR TITLE
PROBLEM: timestamps in csv header repeated multiple times

### DIFF
--- a/src/web/src/average.ecpp
+++ b/src/web/src/average.ecpp
@@ -292,6 +292,7 @@ UserInfo user;
                     zstr_free (&timestamp);
                 }
                 zstr_free (&type_rep);
+                got_timestamps = true;
 
             } // first frame OK
 


### PR DESCRIPTION
BIOS-3520

SOLUTION: Fix it

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>