### PR TITLE
Problem: exported csv's have random order

### DIFF
--- a/src/db/assets/assetr.cc
+++ b/src/db/assets/assetr.cc
@@ -687,6 +687,7 @@ int
             "   v_bios_asset_ext_attributes"
             " WHERE "
             "   read_only = 0"
+            " ORDER BY keytag "
         );
 
         tntdb::Result res = st.select();


### PR DESCRIPTION
Solution: sort the extended attributes at least

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>