### PR TITLE
Problem: groups are not in topology output

### DIFF
--- a/src/include/topology2.h
+++ b/src/include/topology2.h
@@ -28,6 +28,50 @@
 #define SRC_INCLUDE_TOPOLOGY2
 
 namespace persist {
+
+struct Item
+{
+
+struct Topology
+{
+    std::vector <Item> rooms;
+    std::vector <Item> rows;
+    std::vector <Item> racks;
+    std::vector <Item> devices;
+    std::vector <Item> groups;
+
+    Topology () {}
+
+    size_t empty () const {
+        return \
+        rooms.empty () && \
+        rows.empty () && \
+        racks.empty () && \
+        devices.empty ();
+    }
+};
+
+    Item () {}
+
+    Item (
+        const std::string &id,
+        const std::string &name,
+        const std::string &subtype,
+        const std::string &type) :
+        id {id},
+        name {name},
+        subtype {subtype},
+        type {type},
+        contains {}
+        {}
+
+    std::string id;
+    std::string name;
+    std::string subtype;
+    std::string type;
+    Topology contains;
+    friend void operator<<= (cxxtools::SerializationInfo &si, const Item &asset);
+};
 //
 //  maps node to it's kids, ideal structure for feed_by queries
 //
@@ -53,6 +97,12 @@ namespace persist {
 //  feed_by ("epdu2") -> {"epdu2", "srv2.1", "srv2.2"};
 //
 
+//  return all groups for given id
+//
+std::vector <Item>
+topology2_groups (
+    tntdb::Connection& conn,
+    const std::string& id);
 
 //  return a set of devices feeded by feed_by
 //
@@ -86,6 +136,8 @@ topology2_from (
 //  ret - tntdb::Result from topology2_from
 //  filter - show only given devices
 //  feeded_by - if not empty - show only devices from this set
+//  groups - list of groups device belongs to
+//
 
 void
 topology2_from_json (
@@ -93,7 +145,9 @@ topology2_from_json (
     tntdb::Result &res,
     const std::string &from,
     const std::string &filter,
-    const std::set <std::string> &feeded_by);
+    const std::set <std::string> &feeded_by,
+    const std::vector <Item> &groups
+    );
 
 //  serialize topology returned by topology2_from to ostream
 //  recursive variant
@@ -102,13 +156,18 @@ topology2_from_json (
 //  ret - tntdb::Result from topology2_from
 //  filter - show only given devices
 //  feeded_by - if not empty - show only devices from this set
+//  groups - list of groups device belongs to
+//
+
 void
 topology2_from_json_recursive (
     std::ostream &out,
     tntdb::Result &res,
     const std::string &from,
     const std::string &_filter,
-    const std::set <std::string> &feeded_by);
+    const std::set <std::string> &feeded_by,
+    const std::vector <Item> &groups
+    );
 
 };  // namespace persist
 

--- a/src/web/src/topology_location_from2.ecpp
+++ b/src/web/src/topology_location_from2.ecpp
@@ -188,14 +188,17 @@ UserInfo user;
 		feeded_by = persist::topology2_feed_by (conn, feed_by);
 
 	auto result = persist::topology2_from (conn, from);
-	
+    auto groups = persist::topology2_groups (conn, from);
+
 	if (checked_recursive) {
 			persist::topology2_from_json_recursive (
 				reply.out (),
 				result,
 				from,
 				filter,
-				feeded_by);
+				feeded_by,
+                groups
+                );
 	}
 	else {
 			persist::topology2_from_json (
@@ -203,6 +206,8 @@ UserInfo user;
 				result,
 				from,
 				filter,
-				feeded_by);
+				feeded_by,
+                groups
+                );
 	}
 </%cpp>


### PR DESCRIPTION
Solution: add topology2_group function to get a vector of groups for
each item, extend Topology for groups, add it to formatting functions

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>