### PR TITLE
Problem: topology with groups is not displayed

### DIFF
--- a/src/include/topology2.h
+++ b/src/include/topology2.h
@@ -47,7 +47,8 @@ struct Topology
         rooms.empty () && \
         rows.empty () && \
         racks.empty () && \
-        devices.empty ();
+        devices.empty () && \
+        groups.empty ();
     }
 
     void push_back (const Item &it) {


### PR DESCRIPTION
Solution: fix the Topology.empty method to deal with groups as well

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>