### PR TITLE
Problem: topology2 is mature enough to be used

### DIFF
--- a/src/web/src/topology_location_from2.ecpp
+++ b/src/web/src/topology_location_from2.ecpp
@@ -61,9 +61,16 @@ UserInfo user;
 
     {
         std::string from = qparam.param("from");
+        std::string to = qparam.param("to");
         std::string filter = qparam.param("filter");
         std::string feed_by = qparam.param("feed_by");
         std::string recursive = qparam.param("recursive");
+
+        // forward to other ecpp files - topology2 does not (yet) support
+        // ... unlockated elements or to=
+        // ... so fall back to older implementation
+        if (from.empty () || !to.empty ())
+            return DECLINED;
 
         std::transform (recursive.begin(), recursive.end(), recursive.begin(), ::tolower);
         if (recursive == "true") {

--- a/src/web/tntnet.xml
+++ b/src/web/tntnet.xml
@@ -332,10 +332,9 @@
       </args>
     </mapping>
 
-    <!-- development version of a new topology_from call -->
     <mapping>
       <target>topology_location_from2@bios_web</target>
-      <url>^/api/v1/_topology_dev_/location.*$</url>
+      <url>^/api/v1/topology/location.*$</url>
       <method>GET</method>
     </mapping>
 


### PR DESCRIPTION
Solution: drop the _topology_dev_ namespace and prepend topology2 as the
first handler for topology/location API point. fallback to older impl
for unlocated elements and to= queries

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>