### PR TITLE
Problem: parameter 'from' can have value 'none'

### DIFF
--- a/src/web/src/topology_location_from2.ecpp
+++ b/src/web/src/topology_location_from2.ecpp
@@ -70,7 +70,7 @@ UserInfo user;
         // forward to other ecpp files - topology2 does not (yet) support
         // ... unlockated elements or to=
         // ... so fall back to older implementation
-        if (from.empty () || !to.empty ())
+        if (from.empty () || !to.empty () || from == "none")
             return DECLINED;
 
         std::transform (recursive.begin(), recursive.end(), recursive.begin(), ::tolower);


### PR DESCRIPTION
Solution: 'none' handled

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>