### PR TITLE
Problem: need to create a database upon license acceptance

### DIFF
--- a/src/web/src/helpers.cc
+++ b/src/web/src/helpers.cc
@@ -65,6 +65,8 @@ std::map <std::string, std::string> systemctl_service_names = {
     { "fty-mdns-sd", "" },
     { "fty-metric-snmp", "" },
     { "bios-db-init", "" },
+    { "fty-db-init", "" },
+    { "fty-db-upgrade", "" },
     { "bios-fake-th", "" },
     { "bios-networking", "" },
     { "bios-reset-button", "" },

--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -97,20 +97,19 @@ UserInfo user;
             http_die ("internal-error", "Starting of fty-db-init have failed. Consult system logs");
 
         // enable mysql
-        shared::Argv proc_cmd {"sudo", "/bin/systemctl", "enable", "mysql"};
+        proc_cmd = {"sudo", "/bin/systemctl", "enable", "mysql"};
         rv = shared::simple_output (proc_cmd, proc_out, proc_err);
         if (rv != 0)
             http_die ("internal-error", "Cannot enable mysql. Consult system logs");
 
         // enable fty-db-upgrade
-        shared::Argv proc_cmd {"sudo", "/bin/systemctl", "enable", "fty-db-init"};
+        proc_cmd = {"sudo", "/bin/systemctl", "enable", "fty-db-init"};
         rv = shared::simple_output (proc_cmd, proc_out, proc_err);
         if (rv != 0)
             http_die ("internal-error", "Cannot enable fty-db-init. Consult system logs");
 
-
         // enable fty-db-upgrade
-        shared::Argv proc_cmd {"sudo", "/bin/systemctl", "enable", "fty-db-upgrade"};
+        proc_cmd = {"sudo", "/bin/systemctl", "enable", "fty-db-upgrade"};
         rv = shared::simple_output (proc_cmd, proc_out, proc_err);
         if (rv != 0)
             http_die ("internal-error", "Cannot enable fty-db-upgrade. Consult system logs");

--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -103,6 +103,13 @@ UserInfo user;
             http_die ("internal-error", "Cannot enable mysql. Consult system logs");
 
         // enable fty-db-upgrade
+        shared::Argv proc_cmd {"sudo", "/bin/systemctl", "enable", "fty-db-init"};
+        rv = shared::simple_output (proc_cmd, proc_out, proc_err);
+        if (rv != 0)
+            http_die ("internal-error", "Cannot enable fty-db-init. Consult system logs");
+
+
+        // enable fty-db-upgrade
         shared::Argv proc_cmd {"sudo", "/bin/systemctl", "enable", "fty-db-upgrade"};
         rv = shared::simple_output (proc_cmd, proc_out, proc_err);
         if (rv != 0)

--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -96,6 +96,18 @@ UserInfo user;
         if (rv != 0)
             http_die ("internal-error", "Starting of fty-db-init have failed. Consult system logs");
 
+        // enable mysql
+        shared::Argv proc_cmd {"sudo", "/bin/systemctl", "enable", "mysql"};
+        rv = shared::simple_output (proc_cmd, proc_out, proc_err);
+        if (rv != 0)
+            http_die ("internal-error", "Cannot enable mysql. Consult system logs");
+
+        // enable fty-db-upgrade
+        shared::Argv proc_cmd {"sudo", "/bin/systemctl", "enable", "fty-db-upgrade"};
+        rv = shared::simple_output (proc_cmd, proc_out, proc_err);
+        if (rv != 0)
+            http_die ("internal-error", "Cannot enable fty-db-upgrade. Consult system logs");
+
         // once done, read and setup environment files for accessing the database
         static const char* PASSWD_FILE = "/var/lib/fty/sql/mysql/bios-db-rw";
         if (!shared::is_file (PASSWD_FILE))

--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -36,6 +36,8 @@
 #include "cleanup.h"
 #include "helpers.h"
 #include "log.h"
+#include "subprocess.h"
+#include "filesystem.h"
 </%pre>
 <%request scope="global">
 UserInfo user;
@@ -83,5 +85,31 @@ UserInfo user;
     free (accepted_license_file); accepted_license_file = NULL;
     free (current_license_version); current_license_version = NULL;
     free (license_file); license_file = NULL;
+
+    if (!shared::is_dir ("/var/lib/fty/sql/")) {
+
+        // call fty-db-init to start mysql and initialize the database
+        shared::Argv proc_cmd {"sudo", "/bin/systemctl", "start", "fty-db-init"};
+        std::string proc_out, proc_err;
+
+        int rv = shared::simple_output (proc_cmd, proc_out, proc_err);
+        if (rv != 0)
+            http_die ("internal-error", "Starting of fty-db-init have failed. Consult system logs");
+
+        // once done, read and setup environment files for accessing the database
+        static const char* PASSWD_FILE = "/var/lib/fty/sql/mysql/bios-db-rw";
+        if (!shared::is_file (PASSWD_FILE))
+            http_die ("internal-error", "Database password file is missing");
+
+        std::ifstream dbpasswd {PASSWD_FILE};
+        char db_user[256];
+        dbpasswd.getline (db_user, 256);
+        char db_passwd[256];
+        dbpasswd.getline (db_passwd, 256);
+        dbpasswd.close ();
+
+        putenv (db_user);
+        putenv (db_passwd);
+    }
 }
 </%cpp>

--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -86,7 +86,9 @@ UserInfo user;
     free (current_license_version); current_license_version = NULL;
     free (license_file); license_file = NULL;
 
-    if (!shared::is_dir ("/var/lib/fty/sql/")) {
+    // once done, read and setup environment files for accessing the database
+    static const char* PASSWD_FILE = "/var/lib/fty/sql/mysql/bios-db-rw";
+    if (!shared::is_file (PASSWD_FILE))
 
         // call fty-db-init to start mysql and initialize the database
         shared::Argv proc_cmd {"sudo", "/bin/systemctl", "start", "fty-db-init"};
@@ -95,6 +97,10 @@ UserInfo user;
         int rv = shared::simple_output (proc_cmd, proc_out, proc_err);
         if (rv != 0)
             http_die ("internal-error", "Starting of fty-db-init have failed. Consult system logs");
+
+        // once done, check environment files for accessing the database
+        if (!shared::is_file (PASSWD_FILE))
+            http_die ("internal-error", "Database password file is missing");
 
         // enable mysql
         proc_cmd = {"sudo", "/bin/systemctl", "enable", "mysql"};
@@ -114,11 +120,7 @@ UserInfo user;
         if (rv != 0)
             http_die ("internal-error", "Cannot enable fty-db-upgrade. Consult system logs");
 
-        // once done, read and setup environment files for accessing the database
-        static const char* PASSWD_FILE = "/var/lib/fty/sql/mysql/bios-db-rw";
-        if (!shared::is_file (PASSWD_FILE))
-            http_die ("internal-error", "Database password file is missing");
-
+        // and setup db username/password
         std::ifstream dbpasswd {PASSWD_FILE};
         char db_user[256];
         dbpasswd.getline (db_user, 256);

--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -108,7 +108,7 @@ UserInfo user;
         if (rv != 0)
             http_die ("internal-error", "Cannot enable mysql. Consult system logs");
 
-        // enable fty-db-upgrade
+        // enable fty-db-init
         proc_cmd = {"sudo", "/bin/systemctl", "enable", "fty-db-init"};
         rv = shared::simple_output (proc_cmd, proc_out, proc_err);
         if (rv != 0)


### PR DESCRIPTION
Solution: call fty-db-init systemd unit and read and setup the database password
from the /var/lib/fty/sql directory

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>