### PR TITLE
Problem: database credentials not (re)loaded

### DIFF
--- a/src/include/dbpath.h
+++ b/src/include/dbpath.h
@@ -31,8 +31,6 @@
 
 //! Global string with url to the database
 extern std::string url;
-
-//static const std::string url = "mysql:db=box_utf8;user=root;password=test";
-//static const std::string url = "sqlite:/work/core/tools/my1db.db";
+void dbpath ();
 
 #endif //TOOLS_DBPATH_H

--- a/src/shared/dbpath.cc
+++ b/src/shared/dbpath.cc
@@ -22,7 +22,19 @@
 
 #include <stdlib.h>
 
-std::string url = std::string("mysql:db=box_utf8;user=") +
+std::string url;
+
+void dbpath () {
+    url = std::string("mysql:db=box_utf8;user=") +
                   ((getenv("DB_USER")   == NULL) ? "root" : getenv("DB_USER")) +
                   ((getenv("DB_PASSWD") == NULL) ? ""     :
                       std::string(";password=") + getenv("DB_PASSWD"));
+}
+
+static void
+s_init_dbpath () __attribute__((constructor));
+
+static void
+s_init_dbpath () {
+    dbpath ();
+}

--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -36,8 +36,27 @@
 #include "cleanup.h"
 #include "helpers.h"
 #include "log.h"
+#include "dbpath.h"
 #include "subprocess.h"
 #include "filesystem.h"
+
+// drop double quotes from a string
+// needed for reading of db passwd file
+// DB_USER="user" -> DB_USER=user
+// modify buffer in place
+static void
+s_dropdq (char* buffer) {
+    char* dq_ptr = NULL;
+    char* buf = buffer;
+    while ((dq_ptr = strchr (buf, '"')) != NULL) {
+
+        buf = dq_ptr;
+        while (*dq_ptr) {
+            *dq_ptr = *(dq_ptr+1);
+            dq_ptr++;
+        }
+    }
+}
 </%pre>
 <%request scope="global">
 UserInfo user;
@@ -103,14 +122,19 @@ UserInfo user;
 
         // and setup db username/password
         std::ifstream dbpasswd {PASSWD_FILE};
-        char db_user[256];
+        static char db_user[256];
+        memset (db_user, '\0', 256);
         dbpasswd.getline (db_user, 256);
-        char db_passwd[256];
+        s_dropdq (db_user);
+        static char db_passwd[256];
+        memset (db_passwd, '\0', 256);
         dbpasswd.getline (db_passwd, 256);
+        s_dropdq (db_passwd);
         dbpasswd.close ();
 
         putenv (db_user);
         putenv (db_passwd);
+        dbpath ();
     }
 </%cpp>
 { "success" : "License version <$ clv $> accepted." }


### PR DESCRIPTION
Solution: add a function dbpath, which is called
 * from dbpath.o constructor
 * after license is accepted

This way web will have proper credentials for database

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>