### PR TITLE
Problem: unit tests and webserver segfaults

### DIFF
--- a/src/shared/dbpath.cc
+++ b/src/shared/dbpath.cc
@@ -22,7 +22,10 @@
 
 #include <stdlib.h>
 
-std::string url;
+std::string url = std::string("mysql:db=box_utf8;user=") +
+              ((getenv("DB_USER")   == NULL) ? "root" : getenv("DB_USER")) +
+              ((getenv("DB_PASSWD") == NULL) ? ""     :
+                  std::string(";password=") + getenv("DB_PASSWD"));
 
 void dbpath () {
     url = std::string("mysql:db=box_utf8;user=") +
@@ -31,10 +34,3 @@ void dbpath () {
                       std::string(";password=") + getenv("DB_PASSWD"));
 }
 
-static void
-s_init_dbpath () __attribute__((constructor));
-
-static void
-s_init_dbpath () {
-    dbpath ();
-}

--- a/tests/web/src/test-helpers.cc
+++ b/tests/web/src/test-helpers.cc
@@ -25,6 +25,7 @@
  */
 #include <catch.hpp>
 #include "helpers.h"
+#include "dbpath.h"
 
 TEST_CASE ("unicode related stuff", "[helpers]") {
 


### PR DESCRIPTION
Solution: don't use C++ std::string and __attribute__((constructor)) at
the same time. They have an alergy on them.

Signed-off-by: Michal Vyskocil <MichalVyskocil@eaton.com>