### PR TITLE
Problem in debian.rules : should use /etc not /usr/etc for sysconfdir

### DIFF
--- a/obs/debian.rules
+++ b/obs/debian.rules
@@ -29,7 +29,7 @@ build-stamp:
 
 	# Add here commands to compile the package.
 	autoreconf -fi
-	./configure --prefix=/usr --with-saslauthd-mux=/var/run/saslauthd/mux
+	./configure --prefix=/usr --sysconfdir=/etc --with-saslauthd-mux=/var/run/saslauthd/mux
 	make -j4 all
 	# --- end custom part for compiling
 


### PR DESCRIPTION
Solution: fix the file