### PR TITLE
systemctl via helpers.cc : support fty-discovery and fty-sensor-gpio

### DIFF
--- a/src/web/src/helpers.cc
+++ b/src/web/src/helpers.cc
@@ -75,6 +75,7 @@ std::map <std::string, std::string> systemctl_service_names = {
     { "fty-metric-composite-configurator", "" },
     { "fty-metric-tpower", "" },
     { "bios-agent-inventory", "" },
+    { "fty-discovery", "" },
     { "fty-info", "" },
     { "fty-mdns-sd", "" },
     { "fty-metric-snmp", "" },

--- a/src/web/src/helpers.cc
+++ b/src/web/src/helpers.cc
@@ -94,6 +94,7 @@ std::map <std::string, std::string> systemctl_service_names = {
     { "ifplug-dhcp-autoconf", "" },
     { "ipc-meta-setup", "" },
     { "fty-sensor-env", "" },
+    { "fty-sensor-gpio", "" },
     { "fty-nut-configurator", "" },
     { "fty-metric-compute", "" },
     { "fty-metric-cache", "" },

--- a/src/web/src/helpers.cc
+++ b/src/web/src/helpers.cc
@@ -94,7 +94,7 @@ std::map <std::string, std::string> systemctl_service_names = {
     { "ifplug-dhcp-autoconf", "" },
     { "ipc-meta-setup", "" },
     { "fty-sensor-env", "" },
-    { "fty-nut-configuator", "" },
+    { "fty-nut-configurator", "" },
     { "fty-metric-compute", "" },
     { "fty-metric-cache", "" },
     { "fty-alert-flexible", "" },

--- a/src/web/src/json.ecpp
+++ b/src/web/src/json.ecpp
@@ -61,7 +61,7 @@
 	static cxxtools::Regex rex_GET_undecided("^/api/v1/admin/getlog/.*$");
 
 	if(request.getMethod() == "GET") {
-		log_debug( ("GetURL==" + request.getUrl()).c_str() );
+		log_debug("%s", ("GetURL==" + request.getUrl()).c_str() );
 
 		if(rex_GET_text_plain.match(request.getUrl()))
 			reply.setContentType("text/plain;charset=UTF-8");


### PR DESCRIPTION
Update the filter of services that our REST API allows to manipulate, and a couple of typo fixes.