### PR TITLE
Problem: incorrect order in enum for sensorgpio

### DIFF
--- a/src/include/asset_types.h
+++ b/src/include/asset_types.h
@@ -61,11 +61,11 @@ enum asset_subtype {
     ROUTER,
     RACKCONTROLLER,
     SENSOR,
-    SENSORGPIO,
     APPLIANCE,
     CHASSIS,
     PATCHPANEL,
-    OTHER
+    OTHER,
+    SENSORGPIO
 };
 
 enum asset_operation


### PR DESCRIPTION
Solution: corrected

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>