### PR TITLE
Problem : I want more log when new db credentials are set

### DIFF
--- a/src/include/dbpath.h
+++ b/src/include/dbpath.h
@@ -29,8 +29,10 @@
 
 #include <string>
 
+#define PASSWD_FILE  "/etc/default/bios-db-rw"
 //! Global string with url to the database
 extern std::string url;
 void dbpath ();
+bool dbreadcredentails();
 
 #endif //TOOLS_DBPATH_H

--- a/src/include/dbpath.h
+++ b/src/include/dbpath.h
@@ -33,6 +33,6 @@
 //! Global string with url to the database
 extern std::string url;
 void dbpath ();
-bool dbreadcredentails();
+bool dbreadcredentials();
 
 #endif //TOOLS_DBPATH_H

--- a/src/shared/dbpath.cc
+++ b/src/shared/dbpath.cc
@@ -61,7 +61,7 @@ s_dropdq (char* buffer) {
 
 // read /etc/default/bios-db-rw and update url global variable
 // @return 0 if OK, -1 if KO
-bool dbreadcredentails(){
+bool dbreadcredentials(){
     if(!shared::is_file (PASSWD_FILE))return false;
     // and setup db username/password
     log_debug("Reading %s ..",PASSWD_FILE);

--- a/src/shared/dbpath.cc
+++ b/src/shared/dbpath.cc
@@ -19,8 +19,14 @@
  */
 
 #include "dbpath.h"
+#include "log.h"
 
 #include <stdlib.h>
+#include <stdio.h>
+#include <fstream>
+#include <string.h>
+#include <stdlib.h>
+#include "filesystem.h"
 
 std::string url = std::string("mysql:db=box_utf8;user=") +
               ((getenv("DB_USER")   == NULL) ? "root" : getenv("DB_USER")) +
@@ -28,9 +34,50 @@ std::string url = std::string("mysql:db=box_utf8;user=") +
                   std::string(";password=") + getenv("DB_PASSWD"));
 
 void dbpath () {
+    log_info("Updating db url with DB_USER=%s ..",(getenv("DB_USER")   == NULL) ? "root" : getenv("DB_USER"));
     url = std::string("mysql:db=box_utf8;user=") +
                   ((getenv("DB_USER")   == NULL) ? "root" : getenv("DB_USER")) +
                   ((getenv("DB_PASSWD") == NULL) ? ""     :
                       std::string(";password=") + getenv("DB_PASSWD"));
 }
 
+// drop double quotes from a string
+// needed for reading of db passwd file
+// DB_USER="user" -> DB_USER=user
+// modify buffer in place
+static void
+s_dropdq (char* buffer) {
+    char* dq_ptr = NULL;
+    char* buf = buffer;
+    while ((dq_ptr = strchr (buf, '"')) != NULL) {
+
+        buf = dq_ptr;
+        while (*dq_ptr) {
+            *dq_ptr = *(dq_ptr+1);
+            dq_ptr++;
+        }
+    }
+}
+
+// read /etc/default/bios-db-rw and update url global variable
+// @return 0 if OK, -1 if KO
+bool dbreadcredentails(){
+    if(!shared::is_file (PASSWD_FILE))return false;
+    // and setup db username/password
+    log_debug("Reading %s ..",PASSWD_FILE);
+    std::ifstream dbpasswd {PASSWD_FILE};
+    static char db_user[256];
+    memset (db_user, '\0', 256);
+    dbpasswd.getline (db_user, 256);
+    s_dropdq (db_user);
+    static char db_passwd[256];
+    memset (db_passwd, '\0', 256);
+    dbpasswd.getline (db_passwd, 256);
+    s_dropdq (db_passwd);
+    dbpasswd.close ();
+    if(db_user==NULL || db_passwd==NULL)return false;
+    putenv (db_user);
+    putenv (db_passwd);
+    dbpath();
+    return true;
+}

--- a/src/shared/log.c
+++ b/src/shared/log.c
@@ -129,7 +129,7 @@ static int do_logv(
             return -1;
     };
 
-    r = asprintf(&fmt, "[%s]: %s:%d (%s) %s", prefix, file, line, func, format);
+    r = asprintf(&fmt, "[%d.%u] [%s]: %s:%d (%s) %s",getpid(),(unsigned int)pthread_self(), prefix, file, line, func, format);
     if (r == -1) {
         fprintf(log_file, "[ERROR]: %s:%d (%s) can't allocate enough memory for format string: %m", __FILE__, __LINE__, __func__);
         return r;

--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -108,11 +108,11 @@ UserInfo user;
             http_die ("internal-error", "Starting of start-db-services have failed. Consult system logs");
 
         // once done, check environment files for accessing the database
-        if (!dbreadcredentails())
+        if (!dbreadcredentials())
             http_die ("internal-error", "Database password file is missing");
     }else{
         //enforce reload credential
-        if (!dbreadcredentails())
+        if (!dbreadcredentials())
             http_die ("internal-error", "Database password file is missing");  
     }
 </%cpp>

--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -40,23 +40,6 @@
 #include "subprocess.h"
 #include "filesystem.h"
 
-// drop double quotes from a string
-// needed for reading of db passwd file
-// DB_USER="user" -> DB_USER=user
-// modify buffer in place
-static void
-s_dropdq (char* buffer) {
-    char* dq_ptr = NULL;
-    char* buf = buffer;
-    while ((dq_ptr = strchr (buf, '"')) != NULL) {
-
-        buf = dq_ptr;
-        while (*dq_ptr) {
-            *dq_ptr = *(dq_ptr+1);
-            dq_ptr++;
-        }
-    }
-}
 </%pre>
 <%request scope="global">
 UserInfo user;
@@ -105,7 +88,6 @@ UserInfo user;
     free (license_file); license_file = NULL;
 
     // once done, read and setup environment files for accessing the database
-    static const char* PASSWD_FILE = "/etc/default/bios-db-rw";
     if (!shared::is_file (PASSWD_FILE)) {
 
         // call fty-db-init to start mysql and initialize the database
@@ -117,6 +99,7 @@ UserInfo user;
         // consider this thread "hung" and would self-restart after
         // 10 minutes; if this does happen - we should add a thread
         // to report "we're alive" to the server while waiting...
+        log_info("Starting db service .." );
         shared::Argv proc_cmd {"/usr/libexec/fty/start-db-services"};
         std::string proc_out, proc_err;
 
@@ -125,24 +108,12 @@ UserInfo user;
             http_die ("internal-error", "Starting of start-db-services have failed. Consult system logs");
 
         // once done, check environment files for accessing the database
-        if (!shared::is_file (PASSWD_FILE))
+        if (!dbreadcredentails())
             http_die ("internal-error", "Database password file is missing");
-
-        // and setup db username/password
-        std::ifstream dbpasswd {PASSWD_FILE};
-        static char db_user[256];
-        memset (db_user, '\0', 256);
-        dbpasswd.getline (db_user, 256);
-        s_dropdq (db_user);
-        static char db_passwd[256];
-        memset (db_passwd, '\0', 256);
-        dbpasswd.getline (db_passwd, 256);
-        s_dropdq (db_passwd);
-        dbpasswd.close ();
-
-        putenv (db_user);
-        putenv (db_passwd);
-        dbpath ();
+    }else{
+        //enforce reload credential
+        if (!dbreadcredentails())
+            http_die ("internal-error", "Database password file is missing");  
     }
 </%cpp>
 { "success" : "License version <$ clv $> accepted." }

--- a/tests/shared/test-log.cc
+++ b/tests/shared/test-log.cc
@@ -107,13 +107,17 @@ TEST_CASE("log-do_log", "[log][do_log]") {
         exit(1);
     }
     rewind(tempf);
+    char *fmt;
+    int ln = asprintf(&fmt, "[%d.%u] [CRITICAL]: test-log:42 (test_do_log) testing C-formatted string",getpid(),(unsigned int)pthread_self());
+    CHECK(ln!=-1 && ln<1024);
 
     char buf[1024];
-    size_t r = fread((void*) buf, 1, 64, tempf);
+    size_t r = fread((void*) buf, 1, ln, tempf);
 
-    CHECK(r == 64);
-    buf[64] = 0;
-    CHECK(streq(buf, "[CRITICAL]: test-log:42 (test_do_log) testing C-formatted string"));
+    CHECK(r == ln);
+    buf[ln] = 0;
+    
+    CHECK(streq(buf, fmt));
 
     fclose(tempf);
     unlink(temp_name);

--- a/tests/shared/test-log.cc
+++ b/tests/shared/test-log.cc
@@ -109,7 +109,7 @@ TEST_CASE("log-do_log", "[log][do_log]") {
     rewind(tempf);
     char *fmt;
     int ln = asprintf(&fmt, "[%d.%u] [CRITICAL]: test-log:42 (test_do_log) testing C-formatted string",getpid(),(unsigned int)pthread_self());
-    CHECK(ln!=-1 && ln<1024);
+    CHECK(ln!=-1);
 
     char buf[1024];
     size_t r = fread((void*) buf, 1, ln, tempf);


### PR DESCRIPTION
Sometime, when accepting the licence, tntnet fail to connect to DB because of bad credentials.
To investigate this issue
- add [pid.thead_id] in our log
- add info log "Updating db url with DB_USER=" 
- force read bios-db-rw file even if it already exist
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>