### PR TITLE
Problem : several headers are not sent by email

### DIFF
--- a/src/shared/utils_web.cc
+++ b/src/shared/utils_web.cc
@@ -430,10 +430,6 @@ x_headers (zhash_t *headers)
         (void*) (s_getenv ("HARDWARE_SPEC_REVISION", "unknown")));
     zhash_insert (headers, "X-Eaton-IPC-hardware-serial-number",
         (void*) (s_getenv ("HARDWARE_SERIAL_NUMBER", "unknown")));
-
-    std::string machine_id = s_read_all ("/etc/machine-id");
-    if (!machine_id.empty ())
-        zhash_insert (headers, "X-Eaton-IPC-machine-id", (void*) machine_id.c_str ());
 }
 } // namespace utils::email
 


### PR DESCRIPTION
X-Eaton-IPC-image-version and others are missing.
analyze :  X-Eaton-IPC-machine-id ended with a bad return character.
Solution : remove useless machine-id



Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>