### PR TITLE
Problem: UUID sent over mail is random

### DIFF
--- a/src/shared/utils_web.cc
+++ b/src/shared/utils_web.cc
@@ -430,6 +430,8 @@ x_headers (zhash_t *headers)
         (void*) (s_getenv ("HARDWARE_SPEC_REVISION", "unknown")));
     zhash_insert (headers, "X-Eaton-IPC-hardware-serial-number",
         (void*) (s_getenv ("HARDWARE_SERIAL_NUMBER", "unknown")));
+    zhash_insert (headers, "X-Eaton-IPC-hardware-uuid",
+        (void*) (s_getenv ("HARDWARE_UUID", "unknown")));
 }
 } // namespace utils::email
 


### PR DESCRIPTION
Solution: pass the hardware uuid from envvars to the newly introduced header "X-Eaton-IPC-hardware-uuid"; keep the uuid of email in mis-named "X-Eaton-IPC-uuid" header as it was

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

See also https://github.com/42ity/fty-core/pull/142