### PR TITLE
Problem: warnings that getpid() is undefined

### DIFF
--- a/src/shared/log.c
+++ b/src/shared/log.c
@@ -22,6 +22,9 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 #include <stdlib.h>
 #include <errno.h>
 
+#include <sys/types.h>
+#include <unistd.h>
+
 #include "log.h"
 #include "utils.h"
 

--- a/src/web/src/alert_ack.ecpp
+++ b/src/web/src/alert_ack.ecpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <malamute.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <sys/syscall.h>
 
 #include "log.h"

--- a/src/web/src/alert_list.ecpp
+++ b/src/web/src/alert_list.ecpp
@@ -29,6 +29,7 @@
 #include <functional>
 #include <malamute.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <sys/syscall.h>
 #include <tntdb/connection.h>
 #include <tntdb/error.h>

--- a/src/web/src/alert_rules.ecpp
+++ b/src/web/src/alert_rules.ecpp
@@ -30,6 +30,7 @@
 #include <string>
 #include <malamute.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <sys/syscall.h>
 
 #include "log.h"

--- a/src/web/src/alert_rules_detail.ecpp
+++ b/src/web/src/alert_rules_detail.ecpp
@@ -28,6 +28,7 @@
 #include <string>
 #include <malamute.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <sys/syscall.h>
 
 #include "log.h"

--- a/src/web/src/alert_rules_list.ecpp
+++ b/src/web/src/alert_rules_list.ecpp
@@ -29,6 +29,7 @@
 #include <string>
 #include <malamute.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <sys/syscall.h>
 #include "log.h"
 #include "utils_web.h"

--- a/src/web/src/asset_DELETE.ecpp
+++ b/src/web/src/asset_DELETE.ecpp
@@ -24,6 +24,8 @@
  */
  #><%pre>
 #include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "data.h"
 #include "configure_inform.h"

--- a/src/web/src/asset_GET.ecpp
+++ b/src/web/src/asset_GET.ecpp
@@ -28,6 +28,7 @@
  #><%pre>
 #include <cxxtools/regex.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <sys/syscall.h>
 
 #include <fty_proto.h>

--- a/src/web/src/asset_POST.ecpp
+++ b/src/web/src/asset_POST.ecpp
@@ -25,6 +25,8 @@
  */
  #><%pre>
 #include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <cxxtools/jsondeserializer.h>
 #include <cxxtools/serializationinfo.h>

--- a/src/web/src/asset_PUT.ecpp
+++ b/src/web/src/asset_PUT.ecpp
@@ -25,6 +25,8 @@
  */
  #><%pre>
 #include <sys/syscall.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <cxxtools/jsondeserializer.h>
 #include "configure_inform.h"

--- a/src/web/src/asset_import.ecpp
+++ b/src/web/src/asset_import.ecpp
@@ -29,6 +29,8 @@
 #include <fstream>
 #include <sys/syscall.h>
 #include <cstring>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include "log.h"
 #include "db/inout.h"

--- a/src/web/src/datacenter_indicators.ecpp
+++ b/src/web/src/datacenter_indicators.ecpp
@@ -31,6 +31,8 @@
 #include <cxxtools/split.h>
 #include <malamute.h>
 #include <fty_proto.h>
+#include <sys/types.h>
+#include <unistd.h>
 
 #include <math.h>
 #include "data.h"

--- a/src/web/src/uptime.ecpp
+++ b/src/web/src/uptime.ecpp
@@ -25,6 +25,7 @@
  #><%pre>
 #include <malamute.h>
 #include <sys/types.h>
+#include <unistd.h>
 #include <sys/syscall.h>
 #include <cxxtools/split.h>
 #include <tntdb/error.h>

--- a/tests/shared/test-log.cc
+++ b/tests/shared/test-log.cc
@@ -29,6 +29,7 @@
 #include <czmq.h> // for streq macro
 
 #include <cstdio>
+#include <sys/types.h>
 #include <unistd.h>
 
 #include <utils.h>
@@ -116,7 +117,7 @@ TEST_CASE("log-do_log", "[log][do_log]") {
 
     CHECK(r == ln);
     buf[ln] = 0;
-    
+
     CHECK(streq(buf, fmt));
 
     fclose(tempf);


### PR DESCRIPTION
Solution: add headers to files that use it

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>