### PR TITLE
Problem: global variables are not implemented and "normalstate" cannot be not used

### DIFF
--- a/src/agents/autoconfig/rule_templates/state-change@__device_sensorgpio__.rule
+++ b/src/agents/autoconfig/rule_templates/state-change@__device_sensorgpio__.rule
@@ -9,16 +9,13 @@
         "high_critical"  : { "action" : ["EMAIL","SMS"] },
         "high_warning"   : { "action" : ["EMAIL"] }
     },
-    "variables"	    : {
-      "normal_state" : "__normalstate__"
-    },
     "evaluation"    : "
-         function main(current_state)
-	     if current_state == normal_state then
-	         return OK, '' .. NAME .. 'is ok .'
- 	     end
-	         return __severity__ , ' Door ' __logicalasset__ ' is ' .. current_state ..'.'
-         end
+        function main(current_state)
+            if current_state == __normal_state__ then
+                return OK, '' .. NAME .. 'is ok .'
+            end
+                return __severity__ , ' Door ' __logicalasset__ ' is ' .. current_state ..'.'
+        end
     "
   }
 }


### PR DESCRIPTION
Solution: "normalstate" replaced during rule configuration

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>