### PR TITLE
Problem: unsigned long is not always uint64_t

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -113,7 +113,7 @@ int do_log(
         ...) __attribute__ ((format (printf, 5, 6)));
 
 /*! \brief Portable way to get current thread ID */
-unsigned long get_current_thread_id(void);
+uint64_t get_current_thread_id(void);
 
 #define log_macro(level, ...) \
     do { \

--- a/src/shared/log.c
+++ b/src/shared/log.c
@@ -187,10 +187,10 @@ int do_log(
 
 // Return a thread ID number for different platforms
 // https://issues.apache.org/jira/browse/HADOOP-11638
-unsigned long
+uint64_t
 get_current_thread_id(void)
 {
-  unsigned long thread_id = 0;
+  uint64_t thread_id = 0;
 #if defined(__linux__)
   thread_id = (unsigned long)syscall(SYS_gettid);
 #elif defined(__FreeBSD__)


### PR DESCRIPTION
Solution: change function signature

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>