### PR TITLE
Problem: debugging REST API is easier with all process/thread IDs at hand

### DIFF
--- a/src/include/log.h
+++ b/src/include/log.h
@@ -113,7 +113,9 @@ int do_log(
         ...) __attribute__ ((format (printf, 5, 6)));
 
 /*! \brief Portable way to get current thread ID */
-uint64_t get_current_thread_id(void);
+uintmax_t get_current_pthread_id(void);
+uintmax_t get_current_thread_id(void);
+char * asprintf_thread_id(void);
 
 #define log_macro(level, ...) \
     do { \

--- a/src/include/utils_web.h
+++ b/src/include/utils_web.h
@@ -374,6 +374,12 @@ namespace utils {
 */
 uint32_t string_to_element_id (const std::string& string);
 
+/*!
+ \brief  Return an identifier for the MLM client, based on PID/pThreadID/LWP-id
+ \return Provided prefix plus ID from definition above, or plus a random number.
+*/
+std::string generate_mlm_client_id(std::string client_name);
+
 
 namespace json {
 
@@ -382,7 +388,6 @@ namespace json {
  \return Escaped json on success, "(null_ptr)" string on null argument
 */
 std::string escape (const char *string);
-
 
 /*!
  \brief Convenient wrapper for escape"("const char *string")"

--- a/src/shared/ic.c
+++ b/src/shared/ic.c
@@ -20,7 +20,15 @@
 */
 
 #include <stdlib.h>
-#include <string.h>
+
+#ifndef _GNU_SOURCE
+# define _GNU_SOURCE
+# include <string.h>
+# undef _GNU_SOURCE
+#else
+# include <string.h>
+#endif
+
 #include <errno.h>
 #include <iconv.h>
 #include <ctype.h>

--- a/src/shared/log.c
+++ b/src/shared/log.c
@@ -187,9 +187,13 @@ static int do_logv(
             return -1;
     };
 
-    r = asprintf(&fmt, "[%jd.%" PRIu64 "] [%s]: %s:%d (%s) %s",
-        (intmax_t)getpid(), get_current_thread_id(),
-        prefix, file, line, func, format);
+    char *pidstr = asprintf_thread_id();
+    r = asprintf(&fmt, "[%s] [%s]: %s:%d (%s) %s",
+        pidstr ? pidstr : "", prefix, file, line, func, format);
+    if (pidstr) {
+        free(pidstr);
+        pidstr = NULL;
+    }
     if (r == -1) {
         fprintf(log_file, "[ERROR]: %s:%d (%s) can't allocate enough memory for format string: %m", __FILE__, __LINE__, __func__);
         return r;

--- a/src/shared/log.c
+++ b/src/shared/log.c
@@ -203,6 +203,8 @@ static int do_logv(
     free(fmt);   // we don't need it in any case
     if (r == -1) {
         fprintf(log_file, "[ERROR]: %s:%d (%s) can't allocate enough memory for message string: %m", __FILE__, __LINE__, __func__);
+        if (buffer)
+            free(buffer);
         return r;
     }
 
@@ -213,7 +215,6 @@ static int do_logv(
     free(buffer);
 
     return 0;
-
 }
 
 int do_log(

--- a/src/shared/log.c
+++ b/src/shared/log.c
@@ -17,20 +17,25 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 */
 
 #include <assert.h>
-#include <string.h>
-#include <stdlib.h>
 #include <errno.h>
 
 #include <sys/types.h>
-#include <unistd.h>
-#include <sys/syscall.h>
+#include <pthread.h>
 
 #ifndef _GNU_SOURCE
-# define _GNU_SOURCE
+# define _GNU_SOURCE 1
+# include <stdlib.h>
 # include <stdio.h>
+# include <string.h>
+# include <unistd.h>
+# include <sys/syscall.h>
 # undef _GNU_SOURCE
 #else
+# include <stdlib.h>
 # include <stdio.h>
+# include <string.h>
+# include <unistd.h>
+# include <sys/syscall.h>
 #endif
 
 #include "log.h"
@@ -103,6 +108,48 @@ void log_open() {
         }
         log_set_level(log_level);
     }
+}
+
+/* Print "PID.PTHREADID" or "PID.PTHREADID.LWPID" on systems
+ * where PTHREADID != LWPID into a char* buffer string. This
+ * buffer is allocated by asprintf() and freed by caller.
+ * Returns pointer to an empty string on errors.
+ */
+char *
+asprintf_thread_id(void) {
+    uintmax_t process_id = (uintmax_t)getpid();
+    uintmax_t pthread_id = get_current_pthread_id();
+    uintmax_t thread_id = get_current_thread_id();
+    char *buf = NULL;
+    char *buf2 = NULL;
+
+    if (pthread_id != thread_id) {
+        if ( 0 > asprintf(&buf, ".%ju", thread_id) ) {
+            if (buf2) {
+                free (buf2);
+                buf2 = NULL;
+            }
+        }
+    }
+
+    if ( 0 > asprintf(&buf, "%ju.%ju%s",
+        process_id, pthread_id, buf2 ? buf2 : ""
+    ) ) {
+        if (buf) {
+            free (buf);
+            buf = NULL;
+        }
+    }
+
+    if (buf2) {
+        free (buf2);
+        buf2 = NULL;
+    }
+
+    if (buf == NULL)
+        buf = strdup("");
+
+    return buf;
 }
 
 static int do_logv(
@@ -185,22 +232,62 @@ int do_log(
     return r;
 }
 
-// Return a thread ID number for different platforms
-// https://issues.apache.org/jira/browse/HADOOP-11638
-uint64_t
+// Return a thread ID number for different platforms. Inspired by:
+//   https://issues.apache.org/jira/browse/HADOOP-11638
+//   https://github.com/llvm-mirror/llvm/blob/master/lib/Support/Unix/Threading.inc
+// Note that the POSIX pthread_t is a generic type which
+// may be a structure etc. and is not necessarily same as
+// the numeric ID of kernel LWP (which may be the backing
+// implementation detail).
+// See also:
+// https://stackoverflow.com/questions/1759794/how-to-print-pthread-t
+// https://stackoverflow.com/questions/14085515/obtain-lwp-id-from-a-pthread-t-on-solaris-to-use-with-processor-bind
+// https://stackoverflow.com/questions/34370172/the-thread-id-returned-by-pthread-self-is-not-the-same-thing-as-the-kernel-thr
+
+// This routine returns a pthread_self() casted into a
+// numeric value.
+uintmax_t
+get_current_pthread_id(void)
+{
+    int sp = sizeof(pthread_t), si = sizeof(uintmax_t);
+    uintmax_t thread_id = (uintmax_t)pthread_self();
+
+    if ( sp < si ) {
+        // Zero-out extra bits that an uintmax_t value could
+        // have populated above the smaller pthread_t value
+        int shift_bits = (si - sp) << 3; // * 8
+        thread_id = ( (thread_id << shift_bits ) >> shift_bits );
+    }
+
+    return thread_id;
+}
+
+// This routine aims to return LWP number wherever we
+// know how to get its ID.
+uintmax_t
 get_current_thread_id(void)
 {
-  uint64_t thread_id = 0;
+    // Note: implementations below all assume that the routines
+    // return a numeric value castable to uintmax_t, and should
+    // fail during compilation otherwise so we can then fix it.
+    uintmax_t thread_id = 0;
 #if defined(__linux__)
-  thread_id = (unsigned long)syscall(SYS_gettid);
+    // returned actual type: long
+    thread_id = syscall(SYS_gettid);
 #elif defined(__FreeBSD__)
-  thread_id = (unsigned long)pthread_getthreadid_np();
+    // returned actual type: int
+    thread_id = pthread_getthreadid_np();
 #elif defined(__sun)
-  thread_id = (unsigned long)pthread_self();
+// TODO: find a way to extract the LWP ID in current PID
+// It is known ways exist for Solaris 8-11...
+    // returned actual type: pthread_t (which is uint_t in Sol11 at least)
+    thread_id = pthread_self();
 #elif defined(__APPLE__ )
-  (void)pthread_threadid_np(pthread_self(), &thread_id);
+    pthread_t temp_thread_id;
+    (void)pthread_threadid_np(pthread_self(), &temp_thread_id);
+    thread_id = temp_thread_id;
 #else
 #error "Platform not supported: get_current_thread_id() implementation missing"
 #endif
-  return thread_id;
+    return thread_id;
 }

--- a/src/shared/tntmlm.cc
+++ b/src/shared/tntmlm.cc
@@ -20,10 +20,11 @@
 
 #include "log.h"
 #include "tntmlm.h"
+#include "str_defs.h"
 
 MlmClientPool mlm_pool {10};
 
-const std::string MlmClient::ENDPOINT = "ipc://@/malamute";
+const std::string MlmClient::ENDPOINT = MLM_ENDPOINT;
 
 MlmClient::MlmClient ()
 {

--- a/src/warranty/warranty-metric.cc
+++ b/src/warranty/warranty-metric.cc
@@ -29,6 +29,7 @@
 #include <tntdb.h>
 
 #include "log.h"
+#include "str_defs.h"
 #include "dbpath.h"
 #include "db/assets.h"
 
@@ -62,7 +63,7 @@ int main()
 
             std::string date;
             row["date"].get(date);
-            
+
             int day_diff;
             {
                 struct tm tm_ewd;
@@ -102,7 +103,7 @@ int main()
             mlm_client_send (client, subject.c_str (), &msg);
         };
 
-    int r = mlm_client_connect (client, "ipc://@/malamute", 1000, "warranty-metric");
+    int r = mlm_client_connect (client, MLM_ENDPOINT, 1000, "warranty-metric");
     if (r == -1) {
         log_error ("Can't connect to malamute");
         exit (EXIT_FAILURE);

--- a/src/web/src/alert_ack.ecpp
+++ b/src/web/src/alert_ack.ecpp
@@ -127,8 +127,7 @@ if (!client) {
     http_die ("internal-error", "mlm_client_new() failed.");
 }
 
-std::string client_name ("web.alert_ack.");
-client_name.append (std::to_string (getpid ())).append (".").append (std::to_string (get_current_thread_id()));
+std::string client_name = utils::generate_mlm_client_id("web.alert_ack");
 log_debug ("malamute client name = '%s'.", client_name.c_str ());
 
 int rv = mlm_client_connect (client, MLM_ENDPOINT, 1000, client_name.c_str ());

--- a/src/web/src/alert_list.ecpp
+++ b/src/web/src/alert_list.ecpp
@@ -224,8 +224,7 @@ if (!client) {
     http_die ("internal-error", "mlm_client_new() failed.");
 }
 
-std::string client_name ("web.alert_list.");
-client_name.append (std::to_string (getpid ())).append (".").append (std::to_string (get_current_thread_id()));
+std::string client_name = utils::generate_mlm_client_id("web.alert_list");
 log_debug ("malamute client name = '%s'.", client_name.c_str ());
 
 int rv = mlm_client_connect (client, MLM_ENDPOINT, 1000, client_name.c_str ());

--- a/src/web/src/alert_rules.ecpp
+++ b/src/web/src/alert_rules.ecpp
@@ -83,8 +83,7 @@ if (!client) {
     http_die ("internal-error", "mlm_client_new() failed.");
 }
 
-std::string client_name ("web.alert_rules.");
-client_name.append (std::to_string (getpid ())).append (".").append (std::to_string (get_current_thread_id()));
+std::string client_name = utils::generate_mlm_client_id("web.alert_rules");
 log_debug ("malamute client name = '%s'.", client_name.c_str ());
 
 int rv = mlm_client_connect (client, MLM_ENDPOINT, 1000, client_name.c_str ());

--- a/src/web/src/alert_rules_detail.ecpp
+++ b/src/web/src/alert_rules_detail.ecpp
@@ -71,8 +71,7 @@ if (!client) {
     http_die ("internal-error", "mlm_client_new() failed.");
 }
 
-std::string client_name ("web.alert_rules_detailed.");
-client_name.append (std::to_string (getpid ())).append (".").append (std::to_string (get_current_thread_id()));
+std::string client_name = utils::generate_mlm_client_id("web.alert_rules_detailed");
 log_debug ("malamute client name = '%s'.", client_name.c_str ());
 
 int rv = mlm_client_connect (client, MLM_ENDPOINT, 1000, client_name.c_str ());

--- a/src/web/src/alert_rules_list.ecpp
+++ b/src/web/src/alert_rules_list.ecpp
@@ -79,8 +79,7 @@ if (!client) {
     http_die ("internal-error", "mlm_client_new() failed.");
 }
 
-std::string client_name ("web.alert_rules_list.");
-client_name.append (std::to_string (getpid ())).append (".").append (std::to_string (get_current_thread_id()));
+std::string client_name = utils::generate_mlm_client_id("web.alert_rules_list");
 log_debug ("malamute client name = '%s'.", client_name.c_str ());
 
 int rv = mlm_client_connect (client, MLM_ENDPOINT, 1000, client_name.c_str ());

--- a/src/web/src/asset_DELETE.ecpp
+++ b/src/web/src/asset_DELETE.ecpp
@@ -95,10 +95,7 @@ bool database_ready;
 
     // this code can be executed in multiple threads -> agent's name should
     // be unique at the every moment
-    std::string agent_name("web.asset_delete.");
-    agent_name.append (std::to_string ( static_cast<int> (getpid ()) ))
-        .append (".")
-        .append (std::to_string ( get_current_thread_id() ));
+    std::string agent_name = utils::generate_mlm_client_id("web.asset_delete");
     try {
         send_configure (row, persist::asset_operation::DELETE, agent_name);
 </%cpp>

--- a/src/web/src/asset_GET.ecpp
+++ b/src/web/src/asset_GET.ecpp
@@ -226,8 +226,7 @@ bool database_ready;
         http_die ("internal-error", "mlm_client_new() failed.");
     }
 
-    std::string client_name ("web.asset_get.");
-    client_name.append (std::to_string (getpid ())).append (".").append (std::to_string (get_current_thread_id()));
+    std::string client_name = utils::generate_mlm_client_id("web.asset_get");
     log_debug ("malamute client name = '%s'.", client_name.c_str ());
 
     int rv = mlm_client_connect (client, MLM_ENDPOINT, 1000, client_name.c_str ());

--- a/src/web/src/asset_POST.ecpp
+++ b/src/web/src/asset_POST.ecpp
@@ -101,10 +101,7 @@ bool database_ready;
 
         // this code can be executed in multiple threads -> agent's name should
         // be unique at the every moment
-        std::string agent_name("web.asset_post.");
-        agent_name.append (std::to_string ( static_cast<int> (getpid ()) ))
-                  .append (".")
-                  .append (std::to_string ( get_current_thread_id() ));
+        std::string agent_name = utils::generate_mlm_client_id("web.asset_post");
         try{
             send_configure (row.first, row.second, agent_name);
         }

--- a/src/web/src/asset_PUT.ecpp
+++ b/src/web/src/asset_PUT.ecpp
@@ -112,10 +112,7 @@ bool database_ready;
 
         // this code can be executed in multiple threads -> agent's name should
         // be unique at the every moment
-        std::string agent_name("web.asset_put.");
-        agent_name.append (std::to_string ( static_cast<int> (getpid ()) ))
-                  .append (".")
-                  .append (std::to_string ( get_current_thread_id() ));
+        std::string agent_name = utils::generate_mlm_client_id("web.asset_put");
         try{
             send_configure (row.first, row.second, agent_name);
         }

--- a/src/web/src/asset_import.ecpp
+++ b/src/web/src/asset_import.ecpp
@@ -119,10 +119,7 @@ try{
     // in theory
     // this code can be executed in multiple threads -> agent's name should
     // be unique at the every moment
-    std::string agent_name("web.asset_import.");
-    agent_name.append (std::to_string ( static_cast<int> (getpid ()) ))
-              .append (".")
-              .append (std::to_string ( get_current_thread_id() ));
+    std::string agent_name = utils::generate_mlm_client_id("web.asset_import");
     send_configure (okRows, agent_name);
 </%cpp>
 {

--- a/src/web/src/datacenter_indicators.ecpp
+++ b/src/web/src/datacenter_indicators.ecpp
@@ -34,6 +34,7 @@
 #include <unistd.h>
 
 #include <math.h>
+#include "str_defs.h"
 #include "data.h"
 #include "utils_web.h"
 #include "log.h"
@@ -43,7 +44,6 @@
 
 #define RT_PROVIDER_PEER "fty-metric-cache"
 #define RT_SUBJECT "latest-rt-data"
-#define MLM_ENDPOINT "ipc://@/malamute"
 
 
 

--- a/src/web/src/datacenter_indicators.ecpp
+++ b/src/web/src/datacenter_indicators.ecpp
@@ -300,17 +300,15 @@ bool database_ready;
 
     // create mlm client
     mlm_client_t *client = mlm_client_new ();
-    std::string agent_name("web.dc_indicators.");
-    agent_name.append (std::to_string ( static_cast<int> (getpid ()) ))
-              .append (".")
-              .append (std::to_string ( get_current_thread_id() ));
+    std::string client_name = utils::generate_mlm_client_id("web.dc_indicators");
+    int rv = mlm_client_connect (client, MLM_ENDPOINT, 1000, client_name.c_str());
 
-    int rv = mlm_client_connect (client, MLM_ENDPOINT, 1000, agent_name.c_str());
     if ( rv != 0 ) {
-        log_error ("%s: Cannot connect to malamute", agent_name.c_str());
+        log_error ("%s: Cannot connect to malamute", client_name.c_str());
         mlm_client_destroy (&client);
         http_die ("internal-error", "Cannot connect to malamute");
     }
+
     // get current data for all DCs
     for ( const auto &aDc : DCNames ) {
         // fill the request message according the protocol

--- a/src/web/src/uptime.ecpp
+++ b/src/web/src/uptime.ecpp
@@ -101,8 +101,8 @@ bool database_ready;
         if (!client)
             throw std::runtime_error ("Can't allocate malamute client");
 
-        std::string name = "web.uptime." + std::to_string (::getpid ()) + "." + std::to_string (::get_current_thread_id());
-        mlm_client_connect (client, "ipc://@/malamute", 1000, name.c_str());
+        std::string client_name = utils::generate_mlm_client_id("web.uptime");
+        mlm_client_connect (client, "ipc://@/malamute", 1000, client_name.c_str());
 
         json << "{\n\t\"outage\": [\n";
 

--- a/src/web/src/uptime.ecpp
+++ b/src/web/src/uptime.ecpp
@@ -29,6 +29,7 @@
 #include <cxxtools/split.h>
 #include <tntdb/error.h>
 #include "data.h"
+#include "str_defs.h"
 #include "dbpath.h"
 #include "utils_web.h"
 #include "log.h"
@@ -102,7 +103,7 @@ bool database_ready;
             throw std::runtime_error ("Can't allocate malamute client");
 
         std::string client_name = utils::generate_mlm_client_id("web.uptime");
-        mlm_client_connect (client, "ipc://@/malamute", 1000, client_name.c_str());
+        mlm_client_connect (client, MLM_ENDPOINT, 1000, client_name.c_str());
 
         json << "{\n\t\"outage\": [\n";
 

--- a/tests/shared/test-log.cc
+++ b/tests/shared/test-log.cc
@@ -109,8 +109,14 @@ TEST_CASE("log-do_log", "[log][do_log]") {
     }
     rewind(tempf);
     char *fmt;
-    int ln = asprintf(&fmt, "[%jd.%" PRIu64 "] [CRITICAL]: test-log:42 (test_do_log) testing C-formatted string",
-        (intmax_t)getpid(), get_current_thread_id());
+
+    char *pidstr = asprintf_thread_id();
+    int ln = asprintf(&fmt, "[%s] [CRITICAL]: test-log:42 (test_do_log) testing C-formatted string",
+        pidstr ? pidstr : "");
+    if (pidstr) {
+        free(pidstr);
+        pidstr = NULL;
+    }
     CHECK(ln!=-1);
 
     char buf[1024];


### PR DESCRIPTION
Solution: if we have both pThread ID and kernel LWP ID, and they are different, use them in logging as well as in malamute client self-identification (where REST API talks to other components). 

Also took the chance at refactoring the complexity to be in one place, and the leaf code to look simpler.