### PR TITLE
subprocess: Do not close the same file descriptor twice

### DIFF
--- a/src/include/subprocess.h
+++ b/src/include/subprocess.h
@@ -94,6 +94,9 @@ class SubProcess {
         //! \brief get the pipe ends connected to stdin of started program, or -1 if not started
         int getStdin() const { return _inpair[1]; }
 
+	//! \brief close the stdin pipe end
+	int closeStdin();
+
         //! \brief get the pipe ends connected to stdout of started program, or -1 if not started
         int getStdout() const { return _outpair[0]; }
 

--- a/src/shared/subprocess.cc
+++ b/src/shared/subprocess.cc
@@ -46,6 +46,7 @@ struct sbp_info_t {
     std::stringstream &buff;
 };
 
+static int close_forget(int &fd);
 char * const * _mk_argv(const Argv& vec);
 static int s_output(SubProcess& p, std::string& o, std::string& e, uint64_t timeout, size_t timestep);
 static int s_output2(SubProcess& p, std::string& o, uint64_t timeout, size_t timestep);
@@ -96,14 +97,19 @@ SubProcess::~SubProcess() {
     }
 
     // close pipes
-    ::close(_inpair[0]);
-    ::close(_outpair[0]);
-    ::close(_errpair[0]);
-    ::close(_inpair[1]);
-    ::close(_outpair[1]);
-    ::close(_errpair[1]);
+    close_forget(_inpair[0]);
+    close_forget(_outpair[0]);
+    close_forget(_errpair[0]);
+    close_forget(_inpair[1]);
+    close_forget(_outpair[1]);
+    close_forget(_errpair[1]);
 
     errno = _saved_errno;
+}
+
+int SubProcess::closeStdin()
+{
+    return close_forget(_inpair[1]);
 }
 
 bool SubProcess::run() {
@@ -132,14 +138,14 @@ bool SubProcess::run() {
             int n_flags = o_flags & (~O_NONBLOCK);
             fcntl(_inpair[0], F_SETFL, n_flags);
             ::dup2(_inpair[0], STDIN_FILENO);
-            ::close(_inpair[1]);
+            close_forget(_inpair[1]);
         }
         if (_outpair[0] != PIPE_DISABLED) {
-            ::close(_outpair[0]);
+            close_forget(_outpair[0]);
             ::dup2(_outpair[1], STDOUT_FILENO);
         }
         if (_errpair[0] != PIPE_DISABLED) {
-            ::close(_errpair[0]);
+            close_forget(_errpair[0]);
             ::dup2(_errpair[1], STDERR_FILENO);
         }
 
@@ -156,9 +162,9 @@ bool SubProcess::run() {
     }
     // we are in parent
     _state = SubProcessState::RUNNING;
-    ::close(_inpair[0]);
-    ::close(_outpair[1]);
-    ::close(_errpair[1]);
+    close_forget(_inpair[0]);
+    close_forget(_outpair[1]);
+    close_forget(_errpair[1]);
     // update a state
     poll();
     return true;
@@ -281,7 +287,7 @@ int output(const Argv& args, std::string& o, std::string& e, const std::string& 
     p.run();
     ::write(p.getStdin(), i.c_str(), i.size());
     ::fsync(p.getStdin());
-    ::close(p.getStdin());
+    p.closeStdin();
     return s_output (p, o, e, timeout, timestep);
 }
 
@@ -327,6 +333,17 @@ std::string wait_read_all(int fd) {
 }
 
 // ### helper functions ###
+// close fd and set it to -1
+static int close_forget(int &fd) {
+    int res = -1;
+
+    if (fd >= 0)
+        res = ::close(fd);
+    if (res == 0)
+        fd = SubProcess::PIPE_DEFAULT;
+    return res;
+}
+
 char * const * _mk_argv(const Argv& vec) {
 
     char ** argv = (char **) malloc(sizeof(char*) * (vec.size()+1));


### PR DESCRIPTION
Make sure that whenever we close one of the pipe ends, we set it to
PIPE_DEFAULT to avoid closing it again in the destructor. Otherwise, we
could race with a different thread that calls open() or socket()
in-between and gets assigned the same file descriptor.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>