### PR TITLE
Sort assets numerically

### DIFF
--- a/src/db/topology2.cc
+++ b/src/db/topology2.cc
@@ -526,9 +526,10 @@ topology2_from_json (
                 s_get (row, NAME),
                 persist::subtypeid_to_subtype (s_geti (row, SUBTYPE)),
                 persist::typeid_to_type (s_geti (row, TYPE))};
-            item.asset_order = s_get (row, ASSET_ORDER);
-            if (item.asset_order == "(null)") {
-                item.asset_order = "";
+            item.asset_order = s_geti (row, ASSET_ORDER);
+
+            if (item.asset_order < 0) {
+                item.asset_order = 0;
             }
             topo.push_back (item);
 
@@ -670,9 +671,9 @@ topology2_from_json_recursive (
                     s_get (row, NAME),
                     persist::subtypeid_to_subtype (s_geti (row, SUBTYPE)),
                     persist::typeid_to_type (s_geti (row, TYPE))};
-            it.asset_order = s_get (row, ASSET_ORDER);
-            if (it.asset_order == "(null)")
-                it.asset_order = "";
+            it.asset_order = s_geti (row, ASSET_ORDER);
+            if (it.asset_order < 0)
+                it.asset_order = 0;
 
             if (s_geti (row, TYPE) == persist::asset_type::GROUP)
                 s_topology2_devices_in_groups (conn, it);

--- a/src/include/topology2.h
+++ b/src/include/topology2.h
@@ -94,7 +94,7 @@ struct Topology
         subtype {subtype},
         type {type},
         contains {},
-        asset_order {}
+        asset_order (0)
         {}
 
     std::string id;
@@ -102,7 +102,7 @@ struct Topology
     std::string subtype;
     std::string type;
     Topology contains;
-    std::string asset_order;
+    int asset_order;
     friend void operator<<= (cxxtools::SerializationInfo &si, const Item &asset);
 };
 //


### PR DESCRIPTION
Treat asset_order as int and sort it accordingly. Fixes BIOS-4241.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>