### PR TITLE
Problem: Agent fty-kpi-power-uptime cannot match UPSes to datacenters.

### DIFF
--- a/src/shared/fty_asset_uptime_configurator.cc
+++ b/src/shared/fty_asset_uptime_configurator.cc
@@ -256,7 +256,8 @@ bool
         for (auto& ups_it : item.second)
         {
             sprintf (key,"ups%d", i);
-            zhash_insert (aux, key, (void*) ups_it.c_str());
+            char *ups_name = strdup (ups_it.c_str ());
+            zhash_insert (aux, key, (void*) ups_name);
             i++;
         }
     }


### PR DESCRIPTION
Solution: UPS names in datacenter inventory messages are mangled.
That's because c_str() string reference we store goes out of scope immediately,
so we need to store duplicated reference instead.

Signed-off-by: Jana Rapava <janarapava@eaton.com>
(cherry picked from commit 90fc42befd8711d7f5cd21f66d8f9c0643f1de1e)
Signed-off-by: Jana Rapava <janarapava@eaton.com>