### PR TITLE
Problem: font files with Cache-Control HTTP header defined break IE

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -732,6 +732,7 @@ BUILT_SOURCES_bios_web_la = \
 		      src/web/src/list_gpio.cpp \
 		      src/web/src/add_gpio.cpp \
 		      src/web/src/security_headers.cpp \
+		      src/web/src/security_removeheaders.cpp \
 		      src/web/src/gpo_action.cpp
 
 # Track real-git and nodist (generated) sources SEPARATELY

--- a/src/web/src/security_removeheaders.ecpp
+++ b/src/web/src/security_removeheaders.ecpp
@@ -1,6 +1,6 @@
 <#
  #
- # Copyright (C) 2017 Eaton
+ # Copyright (C) 2018 Eaton
  #
  # This program is free software; you can redistribute it and/or modify
  # it under the terms of the GNU General Public License as published by
@@ -18,9 +18,17 @@
  #
  #><#
 /*!
- * \file security_headers.ecpp
+ * \file security_removeheaders.ecpp
+ * example : remove Cache-Control from HTTP headers for all .ttf image files
+ * <mapping>
+ *     <target>security_removeheaders@bios</target>
+ *     <url>\.ttf$</url>
+ *     <args>
+ *         <remove>Cache-Control</remove>
+ *     </args>
+ *   </mapping>
  * \author Gerald Guillaume <GeraldGuillaume@Eaton.com>
- * \brief  set HTTP headers and security headers defined as args in tntnet.xml
+ * \brief  remove HTTP headers defined as args in tntnet.xml
  */
 #><%pre>
 #include "log.h"
@@ -28,13 +36,13 @@
 <%cpp>
     tnt::HttpRequest::args_type my_args=request.getArgs();
     for (std::map<std::string, std::string>::iterator it=my_args.begin(); it!=my_args.end(); ++it){
-        std::string key=it->first+":";
-        std::string value=it->second;
-        //log_debug("set HTTP Reply header %s %s",key.c_str(),value.c_str());
-        reply.setHeader( key, value);
+        std::string key=it->first;
+        //log_debug("remove HTTP Reply header %s:",key.c_str());
+        reply.removeHeader(key+":");
     }
     //log_debug("dumpHeader: %s",reply.dumpHeader().c_str());
 
     /* Go on to next module in tntnet.xml */
     return DECLINED;
 </%cpp>
+

--- a/src/web/tntnet.xml
+++ b/src/web/tntnet.xml
@@ -27,7 +27,16 @@
           <X-Content-Type-Options>nosniff</X-Content-Type-Options>
       </args>
     </mapping>
-    <!-- Serve static files -->
+    <!-- Unset security HTTP header for specific mapping -->
+    <mapping>
+      <target>security_removeheaders@bios_web</target>
+      <url>\.(ttf|otf|eot|woff)$</url>
+      <args>
+          <Cache-Control/>
+          <Pragma/>
+      </args>
+    </mapping>
+     <!-- Serve static files -->
     <mapping>
       <target>static@tntnet</target>
       <pathinfo>./$1</pathinfo>


### PR DESCRIPTION
Cache-Control and Pragma HTTP headers does not allow IE to download well font files resource on F5 or C^+F5  button refresh.
 
Solution : implement a new tntnet servlet "security_removeheaders" witch remove specific HTTP header for specific url mapping.
 

Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>