### PR TITLE
Fix constexpr error in utils_web.h

### DIFF
--- a/src/include/utils_web.h
+++ b/src/include/utils_web.h
@@ -94,7 +94,7 @@ constexpr ssize_t
 _die_idx(const char* key)
 {
     static_assert(std::tuple_size<_WSErrors>::value > N, "_die_idx asked for too big N");
-    return (_errors.at(N).key == key || _errors.at(N).message == key) ? N: _die_idx<N-1>(key);
+    return (strcmp(_errors.at(N).key, key) == 0 || strcmp(_errors.at(N).message, key) == 0) ? N: _die_idx<N-1>(key);
 }
 
 template <>
@@ -102,7 +102,7 @@ constexpr ssize_t
 _die_idx<1>(const char* key)
 {
     static_assert(std::tuple_size<_WSErrors>::value > 1 , "_die_idx asked for too big N");
-    return (_errors.at(1).key == key || _errors.at(1).message == key) ? 1: 0;
+    return (strcmp(_errors.at(1).key, key) == 0 || strcmp(_errors.at(1).message, key) == 0) ? 1: 0;
 }
 
 static int


### PR DESCRIPTION
String literals are not guaranteed to be merged by the compiler, so
the result of "foo" == "foo" is undefined and thus not a constexpr.
Older gcc did not catch this, but gcc7 now rightfully errors out. As a
band-aid, change it to use strcmp(), which is not required by the
standard to be a constexpr for string constants, but it is a constexpr
with gcc. The proper fix would be to use an enum for error codes instead
of strings.