### PR TITLE
Probleme : rack asset creation broken

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -167,6 +167,9 @@ src/web/src/add_gpio.cpp
 src/web/src/server_status.cpp
 src/web/src/security_headers.cpp
 src/web/src/topology_location_from2.cpp
+src/web/src/hw_capability.cpp
+src/web/src/security_removeheaders.cpp
+
 
 tntnet.xml.example
 !src/web/tntnet.xml

--- a/src/shared/utils_json.cc
+++ b/src/shared/utils_json.cc
@@ -30,14 +30,14 @@
 #include "utils_json.h"
 
 struct Outlet
-  {
-    std::string label;
-    bool label_r;
-    std::string type;
-    bool type_r;
-    std::string group;
-    bool group_r;
-  };
+{
+  std::string label;
+  bool label_r;
+  std::string type;
+  bool type_r;
+  std::string group;
+  bool group_r;
+};
 
 std::string getOutletNumber(const std::string &extAttributeName)
 {
@@ -85,11 +85,17 @@ s_rack_realpower_nominal(
   zstr_free(&uuid);
 
   char *result = zmsg_popstr(msg);
-  if (!streq(result, "OK"))
+  if (NULL == result || !streq(result, "OK"))
   {
     log_warning("Error reply for device '%s', result=%s", name.c_str(), result);
-    zstr_free(&result);
-    zmsg_destroy(&msg);
+    if (NULL != result)
+    {
+      zstr_free(&result);
+    }
+    if (msg)
+    {
+      zmsg_destroy(&msg);
+    }
     return ret;
   }
 

--- a/src/shared/utils_json.cc
+++ b/src/shared/utils_json.cc
@@ -30,14 +30,14 @@
 #include "utils_json.h"
 
 struct Outlet
-{
-  std::string label;
-  bool label_r;
-  std::string type;
-  bool type_r;
-  std::string group;
-  bool group_r;
-};
+  {
+    std::string label;
+    bool label_r;
+    std::string type;
+    bool type_r;
+    std::string group;
+    bool group_r;
+  };
 
 std::string getOutletNumber(const std::string &extAttributeName)
 {


### PR DESCRIPTION
Solution : 
For a new rack, the sse make a call to fty-metric-cache, but if fty-metric-cache does not known this new asset, it return result = null.
So add a test if result from metric-cache is null or not.