### PR TITLE
Fix response headers for SSE

### DIFF
--- a/src/web/src/admin_sse.ecpp
+++ b/src/web/src/admin_sse.ecpp
@@ -121,7 +121,6 @@ bool database_ready;
 
     // Sse specification :  https://html.spec.whatwg.org/multipage/server-sent-events.html#server-sent-events
     reply.setContentType("text/event-stream");
-    reply.setHeader(tnt::httpheader::cacheControl, "no-store");
     reply.setDirectMode();
     reply.out().flush();
     

--- a/src/web/src/json.ecpp
+++ b/src/web/src/json.ecpp
@@ -61,12 +61,13 @@
 	static cxxtools::Regex rex_export ("^/api/v1/asset/export.*$");
 	static cxxtools::Regex rex_licensing ("^/api/v1/admin/licensing$");
 	static cxxtools::Regex rex_getlog ("^/api/v1/admin/getlog/.*$");
+	static cxxtools::Regex rex_sse ("^/api/v1/sse.*$");
 
 	if(request.getMethod() == "GET") {
 		log_debug("%s", ("GetURL==" + request.getUrl()).c_str() );
         std::string url = request.getUrl ();
 
-		if (rex_license.match(url) || rex_export.match (url) || rex_licensing.match (url) || rex_getlog.match (url))
+		if (rex_license.match(url) || rex_export.match (url) || rex_licensing.match (url) || rex_getlog.match (url) || rex_sse.match (url))
 			log_debug("Will decide on Content-Type later");
 		else
 			reply.setContentType("application/json;charset=UTF-8");


### PR DESCRIPTION
Our version of tntnet goes nuts if the same header is set twice:

HTTP/1.1 200 OK
Date: Mon, 26 Feb 2018 12:16:35 GMT
Server: Tntnet/2.2.1
Pragma: Options:
nosniff X-XSS-Protectio
nosniff X-XSS-Protection:
1 X-Auth-Token-Presented:
"VtwMNU0z2O1_HZaEsx-BxUT0tZDTgVO6Z5a6yzqsjyUseZPTaMGABfUy" X-Auth-Verify:
access_auth_le

To work around this, skip the SSE servlet in json.ecpp and do not set
the Cache-Control header twice. After this, the headers are correct and
SSE works with Firefox:

HTTP/1.1 200 OK
Date: Mon, 26 Feb 2018 13:53:49 GMT
Server: Tntnet/2.2.1
Cache-Control: no-store
Pragma: no-cache
X-Content-Type-Options: nosniff
X-XSS-Protection: 1
X-Auth-Token-Presented: "-AJt-WTVFTnqhzl0XWU9OUuHpr5_UxeZtMUsliL-O5rSaorup3JJX_GH"
X-Auth-Verify: access_auth_level="3"
Content-Type: text/event-stream