### PR TITLE
fty-rest-scripts.install : revert to single-layered paths to "libexec" scripts

### DIFF
--- a/packaging/debian/fty-rest-scripts.install
+++ b/packaging/debian/fty-rest-scripts.install
@@ -1,4 +1,4 @@
-usr/libexec/*/fty-rest/bios-passwd
-usr/libexec/*/fty-rest/testpass.sh
+usr/libexec/fty-rest/bios-passwd
+usr/libexec/fty-rest/testpass.sh
 usr/share/fty-rest/examples/tntnet.xml.example
 #usr/share/fty-rest/.git_details


### PR DESCRIPTION
Use paths to "libexec" scripts hardcoded in Makemodule-local