### PR TITLE
Fix testpass.sh settings file path

### DIFF
--- a/tools/testpass.sh
+++ b/tools/testpass.sh
@@ -33,7 +33,7 @@ set -e
 export PATH=/sbin:/usr/sbin:/bin:/usr/bin
 export LC_ALL=C
 
-# Some defaults from our default PAM config /etc/pam.d/fty
+# Some defaults from our default PAM config /etc/pam.d/fty-password
 ###    password   requisite       pam_cracklib.so enforce_for_root minlen=8 dcredit=-1 ocredit=-1 ucredit=0 lcredit=0
 # Scoring follows cracklib: http://wpollock.com/AUnix2/PAM-Help.htm#cracklib
 # + 1 point for each char of length
@@ -51,9 +51,9 @@ CHARS_OTHER_MIN=1
 CHARS_OTHER_CREDIT=1
 
 PAMCFG=""
-if [ -s /etc/pam.d/fty ] && [ -r /etc/pam.d/fty ]; then
-    echo "Sourcing settings from /etc/pam.d/fty"
-    PAMCFG="`egrep 'password.*req.*pam_cracklib\.so' /etc/pam.d/fty | egrep -v '^[ \t]*#' | (read _P _R _L OPTS; echo "$OPTS")`" || PAMCFG=""
+if [ -s /etc/pam.d/fty-password ] && [ -r /etc/pam.d/fty-password ]; then
+    echo "Sourcing settings from /etc/pam.d/fty-password"
+    PAMCFG="`egrep 'password.*req.*pam_cracklib\.so' /etc/pam.d/fty-password | egrep -v '^[ \t]*#' | (read _P _R _L OPTS; echo "$OPTS")`" || PAMCFG=""
 
     for T in $PAMCFG; do
         # Take the token after '=' (if any) and strip the first minus (if any)


### PR DESCRIPTION
`testpass.sh` will not find the local password strength policy otherwise (the script doesn't have the logic to process the `@include` directives inside `/etc/pam.d/fty`).