### PR TITLE
Fix a regression in /alerts/activelist

### DIFF
--- a/src/web/src/alert_list.ecpp
+++ b/src/web/src/alert_list.ecpp
@@ -366,6 +366,8 @@ if (streq (part, "LIST")) {
 %   std::string jsonAlert = getJsonAlert(connection,decoded);
 %
 %   if (jsonAlert.empty()){
+%       fty_proto_destroy (&decoded);
+%       frame = zmsg_pop (recv_msg);
 %       continue;
 %   }
 %


### PR DESCRIPTION
fty-alert-engine may send stale entries in the alert list. While this is
probably a bug in the agent, the fty-rest code is attempting to handle
this. It however fails to advance to the next frame if such entry is
encountered. This fixes commit f1c566744224 ("Rebase").