### PR TITLE
Small clean-up for bios-csv recipe

### DIFF
--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -9,7 +9,7 @@ clientdir ?= $(libexecdir)/$(PACKAGE)
 #     defined in condition ENABLE_DB_BIOS_CSV, which is included in
 #     condition TRUE ...
 #   src/Makemodule.am:146: ... 'src_db_bios_csv_LDADD' previously defined here
-src_db_bios_csv_LDADD = ${libzmq_LIBS} ${czmq_LIBS} ${malamute_LIBS} ${cidr_LIBS} ${cxxtools_LIBS} ${tntdb_LIBS} ${magic_LIBS} ${fty_proto_LIBS} ${libsasl2_LIBS} ${log4cplus_LIBS} ${fty_common_LIBS}
+src_db_bios_csv_LDADD := ${libzmq_LIBS} ${czmq_LIBS} ${malamute_LIBS} ${cidr_LIBS} ${cxxtools_LIBS} ${tntdb_LIBS} ${magic_LIBS} ${fty_proto_LIBS} ${libsasl2_LIBS} ${log4cplus_LIBS} ${fty_common_LIBS}
 
 # Statically link bios-csv with everything needed
 if ENABLE_DB_BIOS_CSV

--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -4,6 +4,11 @@
 clientdir ?= $(libexecdir)/$(PACKAGE)
 
 # Do not link bios-csv with libfty_rest or libtntnet
+# Note: ignore the Make warning that
+#   src/Makemodule-local.am:7: warning: src_db_bios_csv_LDADD was already
+#     defined in condition ENABLE_DB_BIOS_CSV, which is included in
+#     condition TRUE ...
+#   src/Makemodule.am:146: ... 'src_db_bios_csv_LDADD' previously defined here
 src_db_bios_csv_LDADD = ${libzmq_LIBS} ${czmq_LIBS} ${malamute_LIBS} ${cidr_LIBS} ${cxxtools_LIBS} ${tntdb_LIBS} ${magic_LIBS} ${fty_proto_LIBS} ${libsasl2_LIBS} ${log4cplus_LIBS} ${fty_common_LIBS}
 
 # Statically link bios-csv with everything needed


### PR DESCRIPTION
In the end, the `:=` assignment did not make the warning go away, but at least it more clearly passes our intention to future-us (and other developers).