### PR TITLE
src/Makemodule-local.am : ensure that bios-passwd gets installed

### DIFF
--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -340,9 +340,10 @@ install-exec-hook-bioscsv:
 
 install-exec-hook-cihelpers:
 	if test x"$(ci_helperdir)" != x"$(prefix)/libexec/$(PACKAGE)" ; then \
+	    mkdir -p "$(DESTDIR)$(prefix)/libexec/$(PACKAGE)" && \
 	    for F in $(ci_helper_SCRIPTS) ; do \
 	        F="`basename "$$F"`"; \
-	        ln -fsr "$(DESTDIR)$(ci_helperdir)/$$F" "$(DESTDIR)$(prefix)/libexec/$(PACKAGE)/" ; \
+	        ln -fsr "$(DESTDIR)$(ci_helperdir)/$$F" "$(DESTDIR)$(prefix)/libexec/$(PACKAGE)/" || exit ; \
 	    done ; \
 	fi
 


### PR DESCRIPTION
Avoid this confusing coexistance of log lines while they are from two targets processed in parallel (and ending up in a race condition, using a directory not yet made):

````
[  801s] mkdir -p "/usr/src/packages/BUILD/debian/tmp/usr/libexec/fty-rest" && \
[  801s]     mv -f "/usr/src/packages/BUILD/debian/tmp/usr/bin/bios-csv" "/usr/src/packages/BUILD/debian/tmp/usr/libexec/fty-rest/"
[  801s] if test x"/usr/lib/arm-linux-gnueabihf/fty-rest" != x"/usr/libexec/fty-rest" ; then \
[  801s]     for F in tools/bios-passwd tools/testpass.sh ; do \
[  801s]         F="`basename "$F"`"; \
[  801s]         ln -fsr "/usr/src/packages/BUILD/debian/tmp/usr/lib/arm-linux-gnueabihf/fty-rest/$F" "/usr/src/packages/BUILD/debian/tmp/usr/libexec/fty-rest/" ; \
[  801s]     done ; \
[  801s] fi
[  801s] ln: target '/usr/src/packages/BUILD/debian/tmp/usr/libexec/fty-rest/' is not a directory: No such file or directory
````