### PR TITLE
Problem: Genset, PDU and Feed should also be enforced

### DIFF
--- a/src/db/inout/importcsv.cc
+++ b/src/db/inout/importcsv.cc
@@ -801,7 +801,6 @@ static std::pair<db_a_elmnt_t, persist::asset_operation>
         if ((SUBTYPES.find("epdu")->second == subtype_id
                 || SUBTYPES.find("sts")->second == subtype_id
                 || SUBTYPES.find("ups")->second == subtype_id
-                || SUBTYPES.find("feed")->second == subtype_id
                 || SUBTYPES.find("genset")->second == subtype_id
                 || SUBTYPES.find("pdu")->second == subtype_id
                 ) && get_active_power_devices() + 1 > limitations.max_active_power_devices) {

--- a/src/db/inout/importcsv.cc
+++ b/src/db/inout/importcsv.cc
@@ -801,6 +801,9 @@ static std::pair<db_a_elmnt_t, persist::asset_operation>
         if ((SUBTYPES.find("epdu")->second == subtype_id
                 || SUBTYPES.find("sts")->second == subtype_id
                 || SUBTYPES.find("ups")->second == subtype_id
+                || SUBTYPES.find("feed")->second == subtype_id
+                || SUBTYPES.find("genset")->second == subtype_id
+                || SUBTYPES.find("pdu")->second == subtype_id
                 ) && get_active_power_devices() + 1 > limitations.max_active_power_devices) {
             bios_throw("action-forbidden", "Asset handling", "Licensing maximum amount of active power devices limit reached");
         }


### PR DESCRIPTION
Solution: Add these part of the licensing tier enforcement

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>