### PR TITLE
Fix rack_total : escape the " or \ in the rackNames

### DIFF
--- a/src/web/src/rack_total.ecpp
+++ b/src/web/src/rack_total.ecpp
@@ -257,7 +257,7 @@ std::string checked_arg2;
             json <<
 "\t\t{\n"
 "\t\t\t\"id\": \"" << racks[R] << "\",\n"
-"\t\t\t\"name\": \"" << rackNames[R] << "\",\n";
+"\t\t\t\"name\": \"" << utils::json::escape(rackNames[R]) << "\",\n";
             for(size_t P = 0; P < requestedParams.size(); P++ ) {
                 const std::string& key = requestedParams[P];
                 const std::string& val = PARAM_TO_SRC.at(key);   //XXX: operator[] does not work here!


### PR DESCRIPTION
Signed-off-by: barraudl <lilianbarraud@eaton.com>