### PR TITLE
Move default preferences to centralized location

### DIFF
--- a/src/db/agentstate/agentstate.cc
+++ b/src/db/agentstate/agentstate.cc
@@ -26,6 +26,8 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 namespace persist {
 
+const static std::string DEFAULT_PARAMETERS = "\"preferences\":{\"email\" : \" \", \"telephone\" : \" \", \"organization\" : \" \", \"date\":\"DDMMYYYY\", \"temperature\":\"C\", \"language\":\"en-us\", \"time\":\"24h\"}";
+
 //=========================
 //lowlevel-functions
 //=========================
@@ -123,9 +125,15 @@ int
         const std::string &data)
 {
     uint16_t rows;
-    
-    return update_agent_info( conn, agent_name, (void *)data.c_str(),
-                              data.size(), rows);
+
+    if (!data.empty()) {
+        return update_agent_info( conn, agent_name, (void *)data.c_str(),
+                                data.size(), rows);
+    }
+    else {
+        return update_agent_info( conn, agent_name, (void *)DEFAULT_PARAMETERS.c_str(),
+                                DEFAULT_PARAMETERS.size(), rows);
+    }
 }
 
 int
@@ -156,9 +164,9 @@ int
 
     if( select_agent_info(conn, agent_name, (void **)&data, size) == 0 ) {
         if( ! data )
-        {   
-            // data is empty
-            return 0;
+        {
+            data = strdup(DEFAULT_PARAMETERS.c_str());
+            size = strlen(data);
         }
         // data is not empty
         data2 = (char *)realloc( data, size + 1 );
@@ -186,6 +194,7 @@ int
         return load_agent_info(connection, agent_name, agent_info);
     } catch( const std::exception &e ) {
         log_info("Cannot load agent %s info: %s", agent_name.c_str(), e.what() );
+        agent_info = DEFAULT_PARAMETERS;
         return -1;
     }
 }

--- a/src/web/src/my_profile.ecpp
+++ b/src/web/src/my_profile.ecpp
@@ -29,7 +29,6 @@
     #include <cxxtools/jsondeserializer.h>
     #include <cxxtools/jsonserializer.h>
     #include "src/db/agentstate/agentstate.h"
-    #define DEFAULT_PREFERENCES "\"preferences\":{\"email\" : \" \", \"telephone\" : \" \", \"organization\" : \" \", \"date\":\"DDMMYYYY\", \"temperature\":\"C\", \"language\":\"en-us\", \"time\":\"24h\"}"
 </%pre>
 <%request scope="global">
     UserInfo user;
@@ -82,21 +81,10 @@
         try
         {
             persist::load_agent_info(uid, preferences);
-            //mitigate the situation DB content is empty - most of the json parsers don't deal well with empty strings
-
         }
         catch (const std::exception &e)
         {
             log_debug ("my_profile: exception caught %s", e.what ());
-        }
-
-        if (preferences.empty()) {
-            // before licence POST = first login... or a DB error...
-            preferences = DEFAULT_PREFERENCES;
-
-            if (database_ready) {
-                log_debug ("my_profile: database is ready but got empty preferences - using default set.");
-            }
         }
 </%cpp>
 {
@@ -125,7 +113,7 @@
             // JSON is correct, try to save it
             cxxtools::SerializationInfo *preferences_si = si.findMember("preferences");
             if ( preferences_si == NULL ) {
-                int rv = persist::save_agent_info (uid, DEFAULT_PREFERENCES);
+                int rv = persist::save_agent_info (uid, "");
 
                 if ( rv != 0 ) {
                     log_debug ("my_profile: Cannot save changes (default)");


### PR DESCRIPTION
This is so that both open-source and proprietary components share the defaults preferences as implemented inside the common API.