### PR TITLE
Hack around fake DELETE asset messages for SSE

### DIFF
--- a/include/shared/configure_inform.h
+++ b/include/shared/configure_inform.h
@@ -33,13 +33,15 @@ void
     send_configure (
         const std::vector <std::pair
             <db_a_elmnt_t, persist::asset_operation>> &rows,
-        const std::string &agent_name);
+        const std::string &agent_name,
+        bool tag_no_not_really = false);
 
 void
     send_configure (
         const db_a_elmnt_t row,
         persist::asset_operation action_type,
-        const std::string &agent_name);
+        const std::string &agent_name,
+        bool tag_no_not_really = false);
 
 void
     send_configure (

--- a/src/shared/configure_inform.cc
+++ b/src/shared/configure_inform.cc
@@ -41,7 +41,7 @@ s_map2zhash (const std::map<std::string, std::string>& m)
 void
     send_configure (
         const std::vector <std::pair<db_a_elmnt_t,persist::asset_operation>> &rows,
-        const std::string &agent_name)
+        const std::string &agent_name, bool tag_no_not_really)
 {
     mlm_client_t *client = mlm_client_new();
 
@@ -81,6 +81,11 @@ void
         zhash_insert (aux, "subtype", (void*) persist::subtypeid_to_subtype (oneRow.first.subtype_id).c_str());
         zhash_insert (aux, "parent", (void*) s_parent.c_str ());
         zhash_insert (aux, "status", (void*) oneRow.first.status.c_str());
+        if (tag_no_not_really) {
+            // FIXME: Inform covertly the SSE that this is not a real DELETE
+            // Remove hack once all agents properly handle the status attribute
+            zhash_insert (aux, "_no_not_really", (void*) "don't delete me");
+        }
 
         // this is a bit hack, but we now that our topology ends with datacenter (hopefully)
         std::string dc_name;
@@ -166,9 +171,10 @@ void
     send_configure (
         db_a_elmnt_t row,
         persist::asset_operation action_type,
-        const std::string &agent_name)
+        const std::string &agent_name,
+        bool tag_no_not_really)
 {
-    send_configure(std::vector<std::pair<db_a_elmnt_t,persist::asset_operation>>{std::make_pair(row, action_type)}, agent_name);
+    send_configure(std::vector<std::pair<db_a_elmnt_t,persist::asset_operation>>{std::make_pair(row, action_type)}, agent_name, tag_no_not_really);
 }
 
 void

--- a/src/web/src/asset_PUT.ecpp
+++ b/src/web/src/asset_PUT.ecpp
@@ -140,7 +140,7 @@ bool database_ready;
         // we don't want to monitor it
         try {
             if (send_inactive) {
-                send_configure (row.first, persist::asset_operation::DELETE, agent_name);
+                send_configure (row.first, persist::asset_operation::DELETE, agent_name, true);
                 return HTTP_OK;
             }
         }

--- a/src/web/src/sse.cc
+++ b/src/web/src/sse.cc
@@ -228,8 +228,8 @@ std::string Sse::changeFtyProtoAsset2Json(fty_proto_t *asset)
 
   std::string nameElement = std::string(fty_proto_name(asset));
   //Check operation 
-  //if delete send json
-  if (streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_DELETE))
+  //if delete for real send json
+  if (streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_DELETE) && !zhash_lookup(fty_proto_aux(asset), "_no_not_really"))
   {
     log_debug("Sse get an delete message");
     if (_assetsOfDatacenter.find(nameElement) == _assetsOfDatacenter.end())
@@ -253,12 +253,16 @@ std::string Sse::changeFtyProtoAsset2Json(fty_proto_t *asset)
     }
     json += "data:{\"topic\":\"asset/" + nameElement + "\",\"payload\":{}}\n\n";
   }
+  // FIXME: fty-rest sends a DELETE when setting an asset to nonactive, hack it back to UPDATE
+  // Remove hack once all agents properly handle the status attribute
   else if (streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_UPDATE)
-          || streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_CREATE))
+          || streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_CREATE)
+          || (streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_DELETE) && zhash_lookup(fty_proto_aux(asset), "_no_not_really")))
   {
     log_debug("Sse get an update or create message");
 
-    if (streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_UPDATE))
+    if (streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_UPDATE)
+       || (streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_DELETE) && zhash_lookup(fty_proto_aux(asset), "_no_not_really")))
     {
       //if update
       //Check if asset is in asset element


### PR DESCRIPTION
This is a stopgap to prevent items in the UI from disappearing whenever a nonactive asset is modified.

**To be properly fixed later.**