### PR TITLE
Problem: subprocess termination is too ungraceful

### DIFF
--- a/include/shared/subprocess.h
+++ b/include/shared/subprocess.h
@@ -1,5 +1,5 @@
 /*
-Copyright (C) 2014 Eaton
+Copyright (C) 2014-2018 Eaton
 
 This program is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -145,6 +145,12 @@ class SubProcess {
         //! \brief terminate the subprocess with SIGKILL/9
         //
         //  This calls wait() to ensure we are not creating zombies
+        //
+        //  @return \see kill
+        int hardkill();
+
+        //! \brief gracefully terminate the subprocess with SIGTERM/15,
+        //   check if died quickly, hardkill() otherwise
         //
         //  @return \see kill
         int terminate();


### PR DESCRIPTION
Solution: have hardkill() for original terminate() job, and terminate() children gracefully

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Practical use-case: child processes like `start-db-services` currently leave no trace if aborted by timeout, despite all error-handling and traps set up in the script. A `SIGTERM` should at least let the script squeak before it dies.