### PR TITLE
Problem: unable to rename active asset when limitation is hit

### DIFF
--- a/include/db/dbhelpers.h
+++ b/include/db/dbhelpers.h
@@ -416,6 +416,6 @@ get_active_power_devices ();
  *          "unknown" - in case of failure
  */
 std::string get_status_from_db (
-        std::string element_name);
+        std::string &element_name);
 
 #endif // SRC_DB_DBHELPERS_H_

--- a/src/db/inout/importcsv.cc
+++ b/src/db/inout/importcsv.cc
@@ -802,7 +802,7 @@ static std::pair<db_a_elmnt_t, persist::asset_operation>
 
     // since we have all the data about the asset, licensing check could be done now
     if (-1 != limitations.max_active_power_devices && "active" == status && TYPES.find("device")->second == type_id) {
-        std::string db_status = get_status_from_db (iname);
+        std::string db_status = get_status_from_db (id_str);
         // limit applies only to assets that are attempted to be activated, but are disabled in database
         // or to new assets, also may trigger in case of DB failure, but that's fine
         if (db_status != "active") {

--- a/src/persist/dbhelpers.cc
+++ b/src/persist/dbhelpers.cc
@@ -296,7 +296,7 @@ get_active_power_devices ()
 }
 
 
-std::string get_status_from_db (std::string element_name) {
+std::string get_status_from_db (std::string &element_name) {
     tntdb::Connection conn;
     try {
         conn = tntdb::connectCached (url);


### PR DESCRIPTION
Solutoin: used the other id as ename_to_iname fails on rename
Backport of #483 