### PR TITLE
src/Makemodule-local.am : ensure that bios-passwd gets installed (1.4)

### DIFF
--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -340,9 +340,10 @@ install-exec-hook-bioscsv:
 
 install-exec-hook-cihelpers:
 	if test x"$(ci_helperdir)" != x"$(prefix)/libexec/$(PACKAGE)" ; then \
+	    mkdir -p "$(DESTDIR)$(prefix)/libexec/$(PACKAGE)" && \
 	    for F in $(ci_helper_SCRIPTS) ; do \
 	        F="`basename "$$F"`"; \
-	        ln -fsr "$(DESTDIR)$(ci_helperdir)/$$F" "$(DESTDIR)$(prefix)/libexec/$(PACKAGE)/" ; \
+	        ln -fsr "$(DESTDIR)$(ci_helperdir)/$$F" "$(DESTDIR)$(prefix)/libexec/$(PACKAGE)/" || exit ; \
 	    done ; \
 	fi
 


### PR DESCRIPTION
Solution seems to work for master over the past weeks, but still fails in 1.4 builds sometimes - apply it there too :)