### PR TITLE
Jenkinsfile support for cleanup of failed builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -111,7 +111,7 @@ pipeline {
             description: 'The clang-format program (v5+) to use for this build, e.g. clang-format-5.0; an empty value means configure-time guesswork',
             name: 'CLANG_FORMAT')
         string (
-            defaultValue: "60",
+            defaultValue: "240",
             description: 'When running tests, use this timeout (in minutes; be sure to leave enough for double-job of a distcheck too)',
             name: 'USE_TEST_TIMEOUT')
         booleanParam (

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -126,6 +126,10 @@ pipeline {
             defaultValue: true,
             description: 'When using temporary subdirs in build/test workspaces, wipe them after the whole job is done successfully?',
             name: 'DO_CLEANUP_AFTER_JOB')
+        booleanParam (
+            defaultValue: true,
+            description: 'When using temporary subdirs in build/test workspaces, wipe them after the whole job is done unsuccessfully (failed)? Note this would not allow postmortems on CI server, but would conserve its disk space.',
+            name: 'DO_CLEANUP_AFTER_FAILED_JOB')
     }
     triggers {
         pollSCM 'H/2 * * * *'
@@ -565,6 +569,16 @@ pipeline {
             sleep 1
             //slackSend (color: "#AA0000", message: "Build ${env.BUILD_NUMBER} of ${env.JOB_NAME} ${currentBuild.result} (<${env.BUILD_URL}|Open>)")
             //emailext (to: "qa@example.com", subject: "Build ${env.JOB_NAME} failed!", body: "Build ${env.BUILD_NUMBER} of ${env.JOB_NAME} ${currentBuild.result}\nSee ${env.BUILD_URL}")
+
+            dir("tmp") {
+                script {
+                    if ( params.DO_CLEANUP_AFTER_FAILED_JOB ) {
+                        deleteDir()
+                    } else {
+                        sh """ echo "NOTE: BUILD AREA OF WORKSPACE `pwd` REMAINS FOR POST-MORTEMS ON `hostname` AND CONSUMES `du -hs . | awk '{print \$1}'` !" """
+                    }
+                }
+            }
         }
     }
 }

--- a/project.xml
+++ b/project.xml
@@ -15,7 +15,12 @@
     <target name = "jenkins" >
         <option name = "agent_label" value = "devel-image &amp;&amp; x86_64" />
         <option name = "triggers_pollSCM" value = "H/2 * * * *" />
-        <option name = "use_test_timeout" value = "60" />
+
+        <!-- Alas, the fty-rest builds are so big, they sometimes
+          queue up (e.g. "merge" rebuilds of several open PRs) and
+          time out. So bigger timeout helps pass those builds and
+          not just waste lots of time. -->
+        <option name = "use_test_timeout" value = "240" />
         <option name = "test_cppcheck" value = "1" />
         <option name = "test_check" value = "0" />
         <option name = "test_memcheck" value = "0" />

--- a/project.xml
+++ b/project.xml
@@ -30,6 +30,11 @@
         <option name = "dist_docs" value = "1" />
         <option name = "do_cleanup_after_build" value = "0" />
         <option name = "do_cleanup_after_job" value = "1" />
+
+        <!-- Alas, the fty-rest builds are so big, they sometimes
+          time out and then consume a lot of disk. No postmortems
+          were actively needed in the past months though. -->
+        <option name = "do_cleanup_after_failed_job" value = "1" />
     </target>
 
     <classfilename keep-tree = "true" pkgincludedir = "true" use-cxx = "true" pretty-print = "no" source-extension = "cc" />


### PR DESCRIPTION
MAYBE adding both a big timeout and removal of builds that *still* fail is a bit of oxymoron... but at least CI disk space will be safer...