### PR TITLE
Don't remove source-linked assets (1.4)

### DIFF
--- a/src/db/asset_general.cc
+++ b/src/db/asset_general.cc
@@ -615,7 +615,7 @@ db_reply_t
         return reply_delete2;
     }
 
-    auto reply_delete3 = delete_asset_links_all (conn, element_id);
+    auto reply_delete3 = delete_asset_links_to (conn, element_id);
     if ( reply_delete3.status == 0 )
     {
         trans.rollback();

--- a/src/web/src/asset_DELETE.ecpp
+++ b/src/web/src/asset_DELETE.ecpp
@@ -83,7 +83,7 @@ bool database_ready;
             http_die("element-not-found", checked_id.c_str ());
         }
         else {
-            http_die("data-conflict",  checked_id.c_str (), "Asset has elements inside, DELETE them first!");
+            http_die("data-conflict",  checked_id.c_str (), "Asset is in use, remove children/power source links first.");
         }
     }
     // here we are -> delete was successful


### PR DESCRIPTION
This prevents removing a feed when assets are using it.