### PR TITLE
Introduce override flag for last DC deletion check

### DIFF
--- a/src/db/asset_general.cc
+++ b/src/db/asset_general.cc
@@ -30,6 +30,7 @@ with this program; if not, write to the Free Software Foundation, Inc.,
 
 namespace persist {
 
+static const char *ENV_OVERRIDE_LAST_DC_DELETION_CHECK = "FTY_OVERRIDE_LAST_DC_DELETION_CHECK";
 
 //=============================================================================
 // transaction is used
@@ -522,23 +523,25 @@ db_reply_t
     LOG_START;
     tntdb::Transaction trans(conn);
 
-    // Don't allow deleting the last datacenter
-    unsigned numDatacentersAfterDelete = conn.prepareCached(
-            " SELECT COUNT(id_asset_element)"
-            " FROM"
-            "   t_bios_asset_element"
-            " WHERE"
-            "   id_type = (select id_asset_element_type from t_bios_asset_element_type where name = 'datacenter') AND"
-            "   id_asset_element != :element"
-        ).set("element", element_id).selectValue().getUnsigned();
-    if (numDatacentersAfterDelete == 0)
-    {
-        db_reply_t ret = db_reply_new();
-        ret.status     = 0;
-        ret.errtype    = DB_ERR;
-        ret.errsubtype = DB_ERROR_DELETEFAIL;
-        ret.msg        = "will not allow last datacenter to be deleted";
-        return ret;
+    // Don't allow the deletion of the last datacenter (unless overriden)
+    if (getenv(ENV_OVERRIDE_LAST_DC_DELETION_CHECK) == nullptr) {
+        unsigned numDatacentersAfterDelete = conn.prepareCached(
+                " SELECT COUNT(id_asset_element)"
+                " FROM"
+                "   t_bios_asset_element"
+                " WHERE"
+                "   id_type = (select id_asset_element_type from t_bios_asset_element_type where name = 'datacenter') AND"
+                "   id_asset_element != :element"
+            ).set("element", element_id).selectValue().getUnsigned();
+        if (numDatacentersAfterDelete == 0)
+        {
+            db_reply_t ret = db_reply_new();
+            ret.status     = 0;
+            ret.errtype    = DB_ERR;
+            ret.errsubtype = DB_ERROR_DELETEFAIL;
+            ret.msg        = "will not allow last datacenter to be deleted";
+            return ret;
+        }
     }
 
     auto reply_delete2 = delete_asset_element_from_asset_groups


### PR DESCRIPTION
This lets the CI override the last datacenter deletion check through environment variables. Tested by adding `FTY_OVERRIDE_LAST_DC_DELETION_CHECK=y` to `/etc/default/fty` and restarting tntnet.