### PR TITLE
Problem: REST API tests get incorrect error code.

### DIFF
--- a/src/db/asset_general.cc
+++ b/src/db/asset_general.cc
@@ -270,9 +270,7 @@ db_reply_t
     if (DBAssets::extname_to_asset_id(element_name) != -1) {
         db_reply_t ret;
         ret.status     = 0;
-        ret.errtype    = DB_ERR;
-        ret.errsubtype = DB_ERROR_BADINPUT;
-        ret.rowid      = 8;
+        ret.errtype    = DATA_CONFLICT_ERR;
         ret.msg        = std::string ("Element '").append (element_name).append ("' cannot be processed because of conflict. Most likely duplicate entry.");
         return ret;
     }
@@ -283,9 +281,7 @@ db_reply_t
     if (streq (status, "nonactive")) {
         db_reply_t ret;
         ret.status     = 0;
-        ret.errtype    = DB_ERR;
-        ret.errsubtype = DB_ERROR_BADINPUT;
-        ret.rowid      = 8;
+        ret.errtype    = DATA_CONFLICT_ERR;
         ret.msg        = std::string ("Element '").append (element_name).append ("' cannot be inactivated. Change status to 'active'.");
         return ret;
     }
@@ -380,9 +376,7 @@ db_reply_t
     if (DBAssets::extname_to_asset_id(element_name) != -1) {
         db_reply_t ret;
         ret.status     = 0;
-        ret.errtype    = DB_ERR;
-        ret.errsubtype = DB_ERROR_BADINPUT;
-        ret.rowid      = 8;
+        ret.errtype    = DATA_CONFLICT_ERR;
         ret.msg        = std::string ("Element '").append (element_name).append ("' cannot be processed because of conflict. Most likely duplicate entry.");
         return ret;
     }


### PR DESCRIPTION
Solution: Make functions in asset_general return error code as errtype, as DB insert functions do now.

Signed-off-by: Jana Rapava <janarapava@eaton.com>