### PR TITLE
tntnet.xml : forbid to GET oauth tokens

### DIFF
--- a/src/web/tntnet.xml
+++ b/src/web/tntnet.xml
@@ -78,9 +78,12 @@
            but since GET requests are by default fully logged with their
            arguments by our server and by any proxies, we don't want
            our clients to use it by mistake. Blocking GET should expose
-           such behavioral regressions early, during CI testing. -->
+           such behavioral regressions early, during CI testing.
+           If some developer needs to test with GET, they can comment
+           the method line below in their local build/deployment.
+           Note that the fty-core::weblib.sh uses POST since long ago. -->
       <url>^/api/v1/oauth2/token$</url>
-      <method>(POST|PUT)</method>
+      <method>POST</method>
     </mapping>
     <!-- Set BiosProfile profile variable if the request is authenticated
          and validate rights are sufficient.

--- a/src/web/tntnet.xml
+++ b/src/web/tntnet.xml
@@ -108,7 +108,7 @@
     <mapping>
       <target>auth@libfty_rest</target>
       <url>^/api/v1/oauth2/revoke$</url>
-      <method>(POST|PUT)</method>
+      <method>POST</method>
     </mapping>
 
     <!-- alerts/activelist -->

--- a/src/web/tntnet.xml
+++ b/src/web/tntnet.xml
@@ -74,7 +74,13 @@
     <!-- We are getting authorized -->
     <mapping>
       <target>auth@libfty_rest</target>
+      <!-- Code for oauth allows GET as an unchecked development path,
+           but since GET requests are by default fully logged with their
+           arguments by our server and by any proxies, we don't want
+           our clients to use it by mistake. Blocking GET should expose
+           such behavioral regressions early, during CI testing. -->
       <url>^/api/v1/oauth2/token$</url>
+      <method>(POST|PUT)</method>
     </mapping>
     <!-- Set BiosProfile profile variable if the request is authenticated
          and validate rights are sufficient.


### PR DESCRIPTION
Make sure our REST API clients (CI tests, Web-GUI, etc.) only use non-logged POST requests for logging in.