### PR TITLE
(S/M) Problem: Manual setting of time sometimes fails.

### DIFF
--- a/src/web/src/time.ecpp
+++ b/src/web/src/time.ecpp
@@ -143,9 +143,9 @@ UserInfo user;
             int64_t delta_time = (int64_t)difftime(setting_time, entry_time);
 
             if ( delta_time > 0 ) {
-                log_warning ("It took " PRIi64 " seconds to get from start of call processing to setting the clock", delta_time);
+                log_warning ("It took %" PRIi64 " seconds to get from start of call processing to setting the clock", delta_time);
                 checked_time += " + ";
-                checked_time += delta_time;
+                checked_time += std::to_string (delta_time);
                 checked_time += " sec";
             }
 


### PR DESCRIPTION
Solution: If the REST API call takes too long, it tries to add the runtime in seconds to the time specified by the user. This did not work before because int64_t has to be explicitly converted to string.

Signed-off-by: Jana Rapava <janarapava@eaton.com>