### PR TITLE
(S/M) Problem: Translation of unneccessary error messages complicates the t…

### DIFF
--- a/src/web/src/sysinfo.ecpp
+++ b/src/web/src/sysinfo.ecpp
@@ -69,10 +69,13 @@
 #define DPKG__LIST__COLUMN_PKGVERSION 2
 #endif
 
+/*
+ * WARNING: Errors from this REST API call are not translated.
+ * If UI ever starts reporting them, this will need to be updated.
+ */
+
 /* If OSIMAGE_BASENAME==NULL - no envvar, tntnet is not running under systemd */
-// FIXME : Wrap into a macro that keeps this as a string
-// value in final JSON, not a key:value object
-const char * OSIMAGE_BASENAME = ( getenv("OSIMAGE_BASENAME") ? getenv("OSIMAGE_BASENAME") : TRANSLATE_ME ("OS image name is not available").c_str () );
+const char * OSIMAGE_BASENAME = ( getenv("OSIMAGE_BASENAME") ? getenv("OSIMAGE_BASENAME") : "OS image name is not available");
 
 void
 get_location (
@@ -132,10 +135,8 @@ get_installation_date (
             // TODO: we should probably check for time_t max/min, but hey!... ;)
             char chtmp[64];
             if (calendar_to_datetime ((time_t) i64, chtmp, 64) == -1) {
-                // FIXME : Wrap into a macro that keeps this as a string
-                // value in final JSON, not a key:value object
-                installation_date = TRANSLATE_ME ("N/A - Error retrieveing installation date");
-                throw std::runtime_error (TRANSLATE_ME ("calendar_to_datetime () failed."));
+                installation_date = "N/A - Error retrieveing installation date";
+                throw std::runtime_error ("calendar_to_datetime () failed.");
             }
             installation_date.assign (chtmp);
         }
@@ -157,11 +158,9 @@ sysinfo_detail (
     output.clear ();
 
     // Certain strings returned to caller in some cases
-    // FIXME : Wrap into a macro that keeps this as a string
-    // value in final JSON, not a key:value object
-    static const std::string UNAUTHORIZED = TRANSLATE_ME ("unauthorized");
-    static const std::string NOTAVAILABLE = TRANSLATE_ME ("N/A");
-    static const std::string NOTLICENSEDYET = TRANSLATE_ME ("License not accepted yet");
+    static const std::string UNAUTHORIZED = "unauthorized";
+    static const std::string NOTAVAILABLE = "N/A";
+    static const std::string NOTLICENSEDYET = "License not accepted yet";
 
     output += "{\n"
     "\t\"operating-system\" : {\n";
@@ -248,9 +247,7 @@ sysinfo_detail (
     output += utils::json::jsonify ("installation-date", installation_date);
     output += "\n";
 
-    // FIXME : Wrap into a macro that keeps this as a string
-    // value in final JSON, not a key:value object
-    std::string location = TRANSLATE_ME ("N/A - Error retrieving location");
+    std::string location = "N/A - Error retrieving location";
     get_location (location);
 
     output += ",\t\t";


### PR DESCRIPTION
…ests.

Solution: Remove TRANSLATE_MEs, add warning for when UI will want to report the errors.

Signed-off-by: Jana Rapava <janarapava@eaton.com>