### PR TITLE
Problem: Directory /usr/lib/bios/ is now the primary one for servlets.

### DIFF
--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -338,7 +338,7 @@ tntnet.xml: src/web/tntnet.xml Makefile
 ### This file contains the TNTNET settings distributed as an example for users
 ### Note: in daemon mode, "stderr > /dev/null" unless errorLog is defined
 tntnet.xml.example: src/web/tntnet.xml Makefile
-	${SED} -e 's|\(.*\)\(<!--.*<dir>/</dir>.*-->.*\)|\1<dir>$(datarootdir)/@PACKAGE@/web</dir>\n\1<compPath>\n\1\ \ \ <entry>$(pkglibdir)</entry>\n\1\ \ \ <entry>$(libdir)</entry>\n\1\ \ \ <entry>$(bios_libexecdir)</entry>\n\1\ \ \ <entry>$(bios_libdir)</entry>\n\1</compPath>|' \
+	${SED} -e 's|\(.*\)\(<!--.*<dir>/</dir>.*-->.*\)|\1<dir>$(datarootdir)/@PACKAGE@/web</dir>\n\1<compPath>\n\1\ \ \ <entry>$(bios_libdir)</entry>\n\1\ \ \ <entry>$(pkglibdir)</entry>\n\1\ \ \ <entry>$(libdir)</entry>\n\1\ \ \ <entry>$(bios_libexecdir)</entry>\n\1</compPath>|' \
 	       -e 's|<!-- <errorLog>/var/log/tntnet/error.log</errorLog> -->|<errorLog>/var/log/tntnet/error.log</errorLog>|' \
 	       -e 's|<port>8000</port>|<port>80</port>|' \
 	       -e 's|<port>8443</port>|<port>443</port>|' \


### PR DESCRIPTION
Solution: Reorder compPath entries properly.

Signed-off-by: Jana Rapava <janarapava@eaton.com>