### PR TITLE
Problem : admin and Material images return vhost not found

### DIFF
--- a/src/web/tntnet.xml
+++ b/src/web/tntnet.xml
@@ -40,7 +40,7 @@
     <mapping>
       <target>static@tntnet</target>
       <pathinfo>./$1</pathinfo>
-      <url>^/((assets|[b-z]).*)</url>
+      <url>^/((assets|[a-z]|[A-Z]).*)</url>
     </mapping>
     <mapping>
       <target>static@tntnet</target>


### PR DESCRIPTION
GET /admin.png or GET/MaterialXXX.png images are not delivered by tntnet static servlet. 
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>