### PR TITLE
(S/L) Problem: We have to change error behaviour of email_* REST API calls.

### DIFF
--- a/src/web/src/email_feedback.ecpp
+++ b/src/web/src/email_feedback.ecpp
@@ -296,6 +296,7 @@ UserInfo user;
     if (streq (msg_subject, "SENDMAIL-ERR"))
     {
         status = "Failed";
+        http_die ("upstream-err", err_message);
     }
     else
     {
@@ -313,7 +314,7 @@ UserInfo user;
     {
         "status" : "<$ status $>",
         "error_code" : <$ err_code $>,
-        "reason" : "<$ UTF8::escape (err_message) $>"
+        "reason" : "<$ err_message $>"
     }
 }
 <%cpp>

--- a/src/web/src/email_test.ecpp
+++ b/src/web/src/email_test.ecpp
@@ -129,6 +129,7 @@ UserInfo user;
     if (streq (msg_subject, "SENDMAIL-ERR"))
     {
         status = "Failed";
+        http_die ("upstream-err", err_message);
     }
     else
     {
@@ -146,7 +147,7 @@ UserInfo user;
     {
         "status" : "<$ status $>",
         "error_code" : <$ err_code $>,
-        "reason" : "<$ UTF8::escape (err_message) $>"
+        "reason" : "<$ err_message $>"
     }
 }
 <%cpp>

--- a/src/web/src/email_vote.ecpp
+++ b/src/web/src/email_vote.ecpp
@@ -193,6 +193,7 @@ UserInfo user;
     if (streq (msg_subject, "SENDMAIL-ERR"))
     {
         status = "Failed";
+        http_die ("upstream-err", err_message);
     }
     else
     {
@@ -210,7 +211,7 @@ UserInfo user;
     {
         "status" : "<$ status $>",
         "error_code" : <$ err_code $>,
-        "reason" : "<$ UTF8::escape (err_message) $>"
+        "reason" : "<$ err_message $>"
     }
 }
 <%cpp>


### PR DESCRIPTION
Solution: Use HTTP error code 502 Bad Gateway.

Signed-off-by: Jana Rapava <janarapava@eaton.com>
*********************************************************************
This PR depends on https://github.com/42ity/fty-common-rest/pull/27 and https://github.com/42ity/fty-email/pull/70; first one is necessary for build.