### PR TITLE
Problem: Manual asset creation doesn't well feed SSE

### DIFF
--- a/src/web/src/sse.cc
+++ b/src/web/src/sse.cc
@@ -281,11 +281,13 @@ std::string Sse::changeFtyProtoAsset2Json(fty_proto_t *asset)
     json += "data:{\"topic\":\"asset/" + nameElement + "\",\"payload\":{}}\n\n";
   }
   else if (streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_UPDATE)
+          || streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_INVENTORY)
           || streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_CREATE))
   {
-    log_debug("Sse get an update or create message");
+    log_debug("Sse get an update, create or inventory message");
 
-    if (streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_UPDATE))
+    if (streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_UPDATE)
+        || streq(fty_proto_operation(asset), FTY_PROTO_ASSET_OP_INVENTORY))
     {
       //if update
       //Check if asset is in asset element


### PR DESCRIPTION
Solution: Also forward inventory message

'inventory' messages complete the 'create' and 'update' messages previously sent
upon manual asset creation, adding the 'ext' attributes set. Conversely,
auto-discovered devices are already prepopulated with all the 'ext', which
explains the difference of behavior

Signed-off-by: Arnaud Quette <arnaud.quette@free.fr>