### PR TITLE
Fix audit logs after #661

### DIFF
--- a/src/web/src/asset_PUT.ecpp
+++ b/src/web/src/asset_PUT.ecpp
@@ -57,9 +57,10 @@ bool database_ready;
     CHECK_USER_PERMISSIONS_OR_DIE (PERMISSIONS);
     std::string id = request.getArg ("id");
 
-    if (id.empty () || !persist::is_ok_name (id.c_str ()))
+    if (id.empty () || !persist::is_ok_name (id.c_str ())) {
         log_info_audit ("Request PUT asset FAILED");
         http_die ("request-param-bad", id.c_str ());
+    }
 
     // Read json, transform to csv, use existing functionality
     cxxtools::SerializationInfo si;

--- a/src/web/src/conf_scan.ecpp
+++ b/src/web/src/conf_scan.ecpp
@@ -336,7 +336,11 @@ UserInfo user;
         http_die ("bad-request-document", err.c_str ());
     }
     else
+    { // Proceed to output
         if (request.getMethod () == "POST")
             log_info_audit ("Request POST conf_scan SUCCESS");
 </%cpp>
 <$$ output $>
+<%cpp>
+    }
+</%cpp>

--- a/src/web/src/gpo_action.ecpp
+++ b/src/web/src/gpo_action.ecpp
@@ -208,6 +208,10 @@ UserInfo user;
         http_die ("internal-error", err.c_str ());
     }
     else
+    { // proceed to output
         log_info_audit ("Request POST gpo_action sensor %s SUCCESS", checked_sensor.c_str ());
 </%cpp>
 {}
+<%cpp>
+    }
+</%cpp>


### PR DESCRIPTION
We now fail the initial wizard due to the missed parenthesis (PR #661 diligently added a lot, missed one).

Also just in case this restores the "else" behavior in a couple of files for their successful outputs after some error-checking.