### PR TITLE
asset_POST.ecpp : return a proper error message for bad input documents

### DIFF
--- a/src/web/src/asset_POST.ecpp
+++ b/src/web/src/asset_POST.ecpp
@@ -56,10 +56,19 @@ bool database_ready;
             };
     CHECK_USER_PERMISSIONS_OR_DIE (PERMISSIONS);
 
-    auto item_pos1 = request.getBody ().find ("\"name\"");
-    auto item_pos2 = request.getBody ().find_first_of ('"', item_pos1 + strlen ("\"name\"") + 1);
-    auto item_pos3 = request.getBody ().find_first_of ('"', item_pos2 + 2);
-    std::string item = request.getBody ().substr (item_pos2, item_pos3 - item_pos2 - 1);
+    // cache the manipulated asset name
+    std::string item;
+    try {
+        auto item_pos1 = request.getBody ().find ("\"name\"");
+        auto item_pos2 = request.getBody ().find_first_of ('"', item_pos1 + strlen ("\"name\"") + 1);
+        auto item_pos3 = request.getBody ().find_first_of ('"', item_pos2 + 2);
+        item = request.getBody ().substr (item_pos2, item_pos3 - item_pos2 - 1);
+    }
+    catch (const std::exception& e) {
+        LOG_END_ABNORMAL (e);
+        log_info_audit ("Request POST asset <undefined> FAILED");
+        http_die ("bad-request-document", e.what ());
+    }
 
     // Read json, transform to csv, use existing functionality
     cxxtools::SerializationInfo si;


### PR DESCRIPTION
Another follow-up to #661 (and #663), broke our tests (and REST API clients) expecting a proper error for POSTing bad inputs.