### PR TITLE
Problem: license_post proceeds even if db-init did not complete

### DIFF
--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -203,6 +203,36 @@ bool database_ready;
             http_die ("internal-error", err.c_str ());
         }
     }
+
+    // Note: it may be that systemd lied about service states above, and that the
+    // start-db-services ended prematurely but without error... before trying DB
+    // credentials, make sure the touch-file from server_status.ecpp does exist.
+    // Note: if we do have credentials from above, at least fty-db-init had begun
+    // its job... (FIXME: Move code up in case fty-db-init failed a lifetime ago?)
+
+    {
+        /* Check whether database has started and initialized yet */
+        struct stat db_stat;
+        char *database_ready_file = get_current_db_initialized_file();
+        if (!database_ready_file) {
+            log_error("Out of memory!");
+            http_die ("internal-error", "Out of memory!");
+        }
+        log_debug("database_ready_file='%s'", database_ready_file);
+
+        /* Stat returns 0 on success, so database_ready is inverted value of it. */
+        int database_ready_flagfile = !stat(database_ready_file, &db_stat);
+        while (!database_ready_flagfile) {
+            // Note: after 10 mins wait tntnet may kill the "hung" loop
+            // and/or the appserver. The database really should be up by
+            // then and maybe it just does not see it (shifted /tmp etc...)
+            log_debug("Database is not ready, stat errno[%d]: %s, wait 3 sec\n", errno, strerror(errno));
+            usleep(3000);
+        }
+        free (database_ready_file); database_ready_file = NULL;
+        // Go on to check connectivity below
+    }
+
 </%cpp>
 { "success" : "License version <$ clv $> accepted." }
 <%cpp>

--- a/src/web/src/license_POST.ecpp
+++ b/src/web/src/license_POST.ecpp
@@ -220,9 +220,8 @@ bool database_ready;
         }
         log_debug("database_ready_file='%s'", database_ready_file);
 
-        /* Stat returns 0 on success, so database_ready is inverted value of it. */
-        int database_ready_flagfile = !stat(database_ready_file, &db_stat);
-        while (!database_ready_flagfile) {
+        /* Stat returns 0 on success */
+        while (0 != stat(database_ready_file, &db_stat)) {
             // Note: after 10 mins wait tntnet may kill the "hung" loop
             // and/or the appserver. The database really should be up by
             // then and maybe it just does not see it (shifted /tmp etc...)


### PR DESCRIPTION
Solution: there may be a few reasons, like a re-POST of the license
request, to *why* this happens. The common solution is to wait for
the fty-db-ready file to exist.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

Note: I was short on time writing this. A maybe better solution is to check file and services any time after we'd run the script and so not assume its (or mlm-subprocess) completion means something certain.  