### PR TITLE
Make PUT netcfg return updated DNS settings.

### DIFF
--- a/src/web/src/netcfg.ecpp
+++ b/src/web/src/netcfg.ecpp
@@ -314,7 +314,29 @@ AUG_GET ("method", method);
 AUG_GET ("address", ip);
 AUG_GET ("netmask", netmask);
 AUG_GET ("gateway", gateway);
-dns = augeas->get_cmd_out ("match /files/etc/resolv.conf/nameserver", true, "\", \"");
+
+if (request.getMethod() == "PUT")
+{
+    std::string dnsRawData = augeas->get_cmd_out ("match /files/etc/network/interfaces/iface[*]/dns-nameservers", true, " ");
+
+    std::set<std::string> dnsSet;
+    cxxtools::split (" ", dnsRawData, std::inserter (dnsSet, dnsSet.end()));
+
+    std::string dnsStr;
+    for (auto ip : dnsSet)
+    {
+        dnsStr += "\"";
+        dnsStr += ip;
+        dnsStr += "\"";
+        dnsStr += ",";
+    }
+    // remove trailing punctuation
+    dns = dnsStr.substr(1, dnsStr.size() -3);
+}
+else
+{
+    dns = augeas->get_cmd_out ("match /files/etc/resolv.conf/nameserver", true, "\", \"");
+}
 
 </%cpp>
 { "<$ checked_iface $>":


### PR DESCRIPTION
When updating DNS settings, they are put into dns-nameservers field of /etc/network/interfaces.
Then after network restart is finished, resolvconf picks them up, merges them with data from DHCP and puts everything into /etc/resolv.conf.

Before this change, both GET and PUT were reading DNS settings from /etc/resolv.conf. Because the network restart is asynchronous to PUT REST API call,
this meant that PUT might have return old DNS settings. Now we are returning the new settings even though they are not used before restart - that is
consistent with how we e.g. return new static IP address even though we are using old one until restart.

Signed-off-by: Jana Rapava <janarapava@eaton.com>