### PR TITLE
Clean config REST endpoint

### DIFF
--- a/src/web/src/config.ecpp
+++ b/src/web/src/config.ecpp
@@ -38,64 +38,378 @@
 #include <fty_common_rest_utils_web.h>
 #include <fty_common_rest_audit_log.h>
 
-// define json serialization objects
-struct Array
-{
-    struct Config
-    {
-        std::string key;
-        std::vector <std::string> value;
-    };
-    Config config;
+/**
+ * FIXME: Move that file into the file-system and maybe split it per components.
+ *
+ * fty-rest doesn't seem to have any way to simply drop files into the
+ * file-system, keep this in memory until that can be reworked.
+ */
+static const char* mapping = R"xxx(
+# FTY
+
+# compatibility
+BIOS_SNMP_COMMUNITY_NAME = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "snmp/community"
+language = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "server/language"
+
+# nut
+BIOS_NUT_POLLING_INTERVAL = ""
+    filepath = "/etc/fty-nut/fty-nut.cfg"
+    treepath = "nut/polling_interval"
+
+# agent-smtp
+BIOS_SMTP_SERVER = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "smtp/server"
+BIOS_SMTP_PORT = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "smtp/port"
+BIOS_SMTP_ENCRYPT = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "smtp/encryption"
+BIOS_SMTP_VERIFY_CA = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "smtp/verify_ca"
+BIOS_SMTP_USER = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "smtp/user"
+BIOS_SMTP_PASSWD = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "smtp/password"
+BIOS_SMTP_FROM = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "smtp/from"
+BIOS_SMTP_SMS_GATEWAY = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "smtp/smsgateway"
+BIOS_SMTP_USE_AUTHENTICATION = ""
+    filepath = "/etc/fty-email/fty-email.cfg"
+    treepath = "smtp/use_auth"
+
+# agent-ms
+BIOS_METRIC_STORE_AGE_RT = ""
+    filepath = "/etc/fty-metric-store/fty-metric-store.cfg"
+    treepath = "store/rt"
+BIOS_METRIC_STORE_AGE_15m = ""
+    filepath = "/etc/fty-metric-store/fty-metric-store.cfg"
+    treepath = "store/15m"
+BIOS_METRIC_STORE_AGE_30m = ""
+    filepath = "/etc/fty-metric-store/fty-metric-store.cfg"
+    treepath = "store/30m"
+BIOS_METRIC_STORE_AGE_1h = ""
+    filepath = "/etc/fty-metric-store/fty-metric-store.cfg"
+    treepath = "store/1h"
+BIOS_METRIC_STORE_AGE_8h = ""
+    filepath = "/etc/fty-metric-store/fty-metric-store.cfg"
+    treepath = "store/8h"
+BIOS_METRIC_STORE_AGE_24h = ""
+    filepath = "/etc/fty-metric-store/fty-metric-store.cfg"
+    treepath = "store/24h"
+BIOS_METRIC_STORE_AGE_7d = ""
+    filepath = "/etc/fty-metric-store/fty-metric-store.cfg"
+    treepath = "store/7d"
+BIOS_METRIC_STORE_AGE_30d = ""
+    filepath = "/etc/fty-metric-store/fty-metric-store.cfg"
+    treepath = "store/30d"
+
+# fty-discovery
+FTY_DISCOVERY_TYPE = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "discovery/type"
+FTY_DISCOVERY_SCANS = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "discovery/scans"
+FTY_DISCOVERY_IPS = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "discovery/ips"
+FTY_DISCOVERY_DOCUMENTS = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "discovery/documents"
+FTY_DISCOVERY_DEFAULT_VALUES_STATUS = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "discovery/defaultValuesAux/status"
+FTY_DISCOVERY_DEFAULT_VALUES_PRIORITY = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "discovery/defaultValuesAux/priority"
+FTY_DISCOVERY_DEFAULT_VALUES_PARENT = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "discovery/defaultValuesAux/parent"
+FTY_DISCOVERY_DEFAULT_VALUES_LINK_SRC = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "discovery/defaultValuesLinks/0/src"
+
+# fty-discovery parameters
+FTY_DISCOVERY_DUMP_POOL = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "parameters/maxDumpPoolNumber"
+FTY_DISCOVERY_SCAN_POOL = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "parameters/maxScanPoolNumber"
+FTY_DISCOVERY_SCAN_TIMEOUT = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "parameters/nutScannerTimeOut"
+FTY_DISCOVERY_DUMP_LOOPTIME = ""
+    filepath = "/etc/fty-discovery/fty-discovery.cfg"
+    treepath = "parameters/dumpDataLoopTime"
+
+# fty-session
+FTY_SESSION_TIMEOUT_NO_ACTIVITY = ""
+    filepath = "/etc/fty/fty-session.cfg"
+    treepath = "timeout/no_activity"
+FTY_SESSION_TIMEOUT_LEASE = ""
+    filepath = "/etc/fty/fty-session.cfg"
+    treepath = "timeout/lease_time"
+
+# IPM2
+
+# etn-graphite
+ETN_GRAPHITE_FREQUENCY = ""
+    filepath = "/etc/etn-graphite/etn-graphite.cfg"
+    treepath = "configuration/frequency"
+ETN_GRAPHITE_SERVER_ADDR = ""
+    filepath = "/etc/etn-graphite/etn-graphite.cfg"
+    treepath = "server/address"
+ETN_GRAPHITE_SERVER_PORT = ""
+    filepath = "/etc/etn-graphite/etn-graphite.cfg"
+    treepath = "server/port"
+ETN_GRAPHITE_BASENAME = ""
+    filepath = "/etc/etn-graphite/etn-graphite.cfg"
+    treepath = "configuration/basename"
+ETN_GRAPHITE_ACTIVATE = ""
+    filepath = "/etc/etn-graphite/etn-graphite.cfg"
+    treepath = "configuration/activated"
+
+# etn-automation
+ETN_AUTOMATION_POLICY_TIMEOUT = ""
+    filepath = "/etc/fty/etn-automation.cfg"
+    treepath = "policy/global_timeout"
+ETN_AUTOMATION_TASK_TIMEOUT = ""
+    filepath = "/etc/fty/etn-automation.cfg"
+    treepath = "policy/task_timeout"
+ETN_AUTOMATION_NOTIF_EMAIL = ""
+    filepath = "/etc/fty/etn-automation.cfg"
+    treepath = "notifications"
+)xxx";
+
+// JSON <-> ZPL helpers
+
+/**
+ * FIXME: Pretend we have zconfig_remove().
+ *
+ * The following function requires zconfig_remove(), but this is a draft API
+ * and the version inside 42ity is old and buggy. Grant ourselves knowledge
+ * of the underlying struct and of the correct zconfig_remove() implementation.
+ *
+ * This is incredibly dirty and dangerous, but short of lobbying upstream to
+ * promote this API as stable and then upgrading 42ity's czmq, there's nothing
+ * that can be done about it.
+ */
+
+struct _zconfig_t {
+    char *name;                 //  Property name if any
+    char *value;                //  Property value, if any
+    struct _zconfig_t
+    *child,                     //  First child if any
+    *next,                      //  Next sibling if any
+    *parent;                    //  Parent if any
+    zlist_t *comments;          //  Comments if any
+    zfile_t *file;              //  Config file handle
 };
 
-struct Value
-{
-    struct Config
-    {
-        std::string key;
-        std::string value;
-    };
-    Config config;
-};
+#define freen(x) do {free(x); x = NULL;} while(0)
 
-void operator<<= (cxxtools::SerializationInfo& si, const Array::Config& config)
+void
+zconfig_remove_subtree (zconfig_t *self)
 {
-    si.addMember ("key") <<= config.key;
-    si.addMember ("value") <<= config.value;
-}
-void operator<<= (cxxtools::SerializationInfo& si, const Array& array)
-{
-    si.addMember ("config") <<= array.config;
+    assert (self);
+
+    //  Destroy all children
+    zconfig_destroy (&self->child);
+    self->child = NULL;
 }
 
+void
+zconfig_remove (zconfig_t **self_p)
+{
+    assert (self_p);
 
-void operator<<= (cxxtools::SerializationInfo& si, const Value::Config& config)
-{
-    si.addMember ("key") <<= config.key;
-    si.addMember ("value") <<= config.value;
-}
-void operator<<= (cxxtools::SerializationInfo& si, const Value& value)
-{
-    si.addMember ("config") <<= value.config;
-}
+    if (*self_p == NULL)
+        return;
 
-zconfig_t *
-load_config_file (const std::string& key)
-{
-    std::string file = utils::config::get_path (key);
-    zconfig_t *config = zconfig_load (file.c_str ());
-    if (!config) {
-        std::size_t last_slash = file.find_last_of ("/");
-        int rv = zsys_dir_create ("%s", file.substr (0, last_slash).c_str ());
-        if (rv != 0) {
-            log_error ("zsys_dir_create (\"%s\") failed.", file.substr (0, last_slash).c_str ());
-            return NULL;
+    zconfig_t *self = *self_p;
+
+    //  Destroy all children
+    zconfig_remove_subtree (self);
+
+    if (self->parent) {
+        if (self->parent->child == self) {
+           self->parent->child = self->next;
         }
-        return zconfig_new ("root", NULL);
+        else {
+            zconfig_t *prev = self->parent->child;
+            while (prev->next != self) {
+                prev = prev->next;
+            }
+            prev->next = self->next;
+        }
     }
-    return config;
+
+    //  Destroy other properties and then self
+    zlist_destroy (&self->comments);
+    zfile_destroy (&self->file);
+    freen (self->name);
+    freen (self->value);
+    freen (self);
+    *self_p = NULL;
 }
+
+void operator<<=(zconfig_t* root, const cxxtools::SerializationInfo& si) {
+    while (zconfig_child(root)) {
+        zconfig_t* childRoot = zconfig_child(root);
+        zconfig_remove(&childRoot);
+    }
+
+    std::string value;
+    size_t cpt = 0;
+
+    switch (si.category()) {
+        case cxxtools::SerializationInfo::Void:
+            zconfig_set_value(root, nullptr);
+            break;
+
+        case cxxtools::SerializationInfo::Value:
+            si.getValue(value);
+            zconfig_set_value(root, "%s", value.c_str());
+            break;
+
+        case cxxtools::SerializationInfo::Object:
+            // FIXME: Add a '= ""' to the entry, should correct augeas lens.
+            zconfig_set_value(root, "%s", "");
+
+            for (const auto& childSi : si) {
+                zconfig_new(childSi.name().c_str(), root) <<= childSi;
+            }
+            break;
+
+        case cxxtools::SerializationInfo::Array:
+            // FIXME: Add a '= ""' to the entry, should correct augeas lens.
+            zconfig_set_value(root, "%s", "");
+
+            for (const auto& childSi : si) {
+                zconfig_new(std::to_string(cpt++).c_str(), root) <<= childSi;
+            }
+            break;
+    }
+}
+
+void operator<<=(cxxtools::SerializationInfo& si, zconfig_t* root) {
+    if (zconfig_child(root) == nullptr) {
+        const char* value = zconfig_value(root);
+        if (!value) {
+            si.setNull();
+        }
+        else {
+            try {
+                si.setValue(std::stoi(value));
+            }
+            catch (std::invalid_argument& e) {
+                si.setValue(value);
+            }
+        }
+    }
+    else {
+        bool isArray = true;
+        size_t cpt = 0;
+        for (zconfig_t* childRoot = zconfig_child(root); childRoot; childRoot = zconfig_next(childRoot)) {
+            if (std::to_string(cpt++) != zconfig_name(childRoot)) {
+                isArray = false;
+                break;
+            }
+        }
+
+        for (zconfig_t* childRoot = zconfig_child(root); childRoot; childRoot = zconfig_next(childRoot)) {
+            si.addMember(isArray ? "" : zconfig_name(childRoot)) <<= childRoot;
+        }
+        si.setCategory(isArray ? cxxtools::SerializationInfo::Array : cxxtools::SerializationInfo::Object);
+    }
+}
+
+using ConfigEntry = std::pair<std::string, std::string>;
+using ConfigMap = std::map<std::string, ConfigEntry>;
+
+cxxtools::SerializationInfo loadConfig(const ConfigMap& configMap, const std::string& key) {
+    auto it = configMap.find(key);
+    if (it == configMap.end()) {
+        bios_throw("element-not-found", key.c_str());
+    }
+
+    zconfig_t* root = zconfig_load(it->second.first.c_str());
+    if (!root) {
+        bios_throw("element-not-found", it->second.first.c_str());
+    }
+
+    zconfig_t* child = zconfig_locate(root, it->second.second.c_str());
+    if (!child) {
+        zconfig_destroy(&root);
+        bios_throw("element-not-found", it->second.second.c_str());
+    }
+
+    cxxtools::SerializationInfo si;
+    si <<= child;
+    si.setName("value");
+
+    zconfig_destroy(&root);
+    return si;
+}
+
+void saveConfig(const ConfigMap& configMap, const std::string& key, const cxxtools::SerializationInfo& in) {
+    auto it = configMap.find(key);
+    if (it == configMap.end()) {
+        bios_throw("element-not-found", key.c_str());
+    }
+
+    zconfig_t* root = zconfig_load(it->second.first.c_str());
+    if (!root) {
+        bios_throw("element-not-found", it->second.first.c_str());
+    }
+
+    zconfig_t* child = zconfig_locate(root, it->second.second.c_str());
+    if (!child) {
+        /**
+         * FIXME: Entry is missing, force its creation.
+         *
+         * We should not have to do that, but etn-graphite doesn't have a
+         * server/address entry in its config file, among other things...
+         */
+        zconfig_put(root, it->second.second.c_str(), "");
+        child = zconfig_locate(root, it->second.second.c_str());
+    }
+
+    child <<= in;
+    int r = zconfig_save(root, it->second.first.c_str());
+    zconfig_destroy(&root);
+
+    if (r != 0) {
+        bios_throw("internal-error", (std::string("Failed to save file ") + it->second.first).c_str());
+    }
+}
+
+ConfigMap loadMapping(zconfig_t* root) {
+    ConfigMap result;
+
+    for (zconfig_t* childRoot = zconfig_child(root); childRoot; childRoot = zconfig_next(childRoot)) {
+        result.emplace(zconfig_name(childRoot), ConfigEntry(
+            zconfig_get(childRoot, "filepath", nullptr),
+            zconfig_get(childRoot, "treepath", nullptr)
+        ));
+    }
+
+    return result;
+}
+
 </%pre>
 <%application scope="page">
     std::mutex config_mux;
@@ -108,76 +422,37 @@ UserInfo user;
     // check user permissions
     static const std::map <BiosProfile, std::string> PERMISSIONS =
     {
-        {BiosProfile::Admin,     "CR"}
+        { BiosProfile::Admin,     "CR" }
     };
+
     std::string audit_msg;
     if (request.getMethod () == "POST")
         audit_msg = std::string ("Request CREATE config FAILED");
     CHECK_USER_PERMISSIONS_OR_DIE_AUDIT (PERMISSIONS, audit_msg.empty () ? nullptr : audit_msg.c_str ());
 
-    std::string key_format_string = "^[-._a-zA-Z0-9]+$";
-    cxxtools::Regex key_format (key_format_string);
-    std::string value_format_string = "^[[:blank:][:alnum:][:punct:]]*$";
-    cxxtools::Regex value_format (value_format_string);
+    zconfig_t* mappingZconfig = zconfig_str_load(mapping);
+    ConfigMap mapping = loadMapping(mappingZconfig);
+    zconfig_destroy(&mappingZconfig);
 
     ///////////////////
     ///     GET     ///
     ///////////////////
     if (request.isMethodGET ()) {
-        std::string checked_key;
-        {
-            std::string key = qparam.param ("key");
-            if (!key_format.match (key)) {
-                std::string msg = std::string (TRANSLATE_ME ("satisfy format ")) + key_format_string;
-                http_die ("request-param-bad", "key", key.c_str (), msg.c_str () );
-            }
-            checked_key = std::move (key);
+        std::string key = qparam.param ("key");
+        if (key.empty()) {
+            http_die ("request-param-required", "key");
         }
-
-        std::lock_guard<std::mutex> lock (config_mux);
-        zconfig_t *root = zconfig_load (utils::config::get_path (checked_key));
-        if (!root) {
-            http_die ("element-not-found", checked_key.c_str ());
-        }
-
-        const char *config_key = utils::config::get_mapping (checked_key);
-        zconfig_t *item = zconfig_locate (root, config_key);
-        if (!item) {
-            zconfig_destroy (&root);
-            http_die ("element-not-found", checked_key.c_str ());
-        }
-
-        bool is_array = false;
-        std::string value = zconfig_value (item);
-        std::vector <std::string> array;
-        zconfig_t *child = zconfig_child (item);
-        if (child) {
-            while (child) {
-                if (!streq (zconfig_value (child), "")) {
-                    is_array = true;
-                    array.push_back (zconfig_value (child));
-                }
-                child = zconfig_next (child);
-            }
-        }
-        zconfig_destroy (&root);
-
         cxxtools::JsonSerializer serializer (reply.out ());
         serializer.beautify (true);
 
-        if (is_array) {
-            Array json;
-            json.config.key = checked_key;
-            json.config.value = std::move (array);
-            serializer.serialize (json).finish ();
-        }
-        else
-        {
-            Value json;
-            json.config.key = checked_key;
-            json.config.value = value;
-            serializer.serialize (json).finish ();
-        }
+        cxxtools::SerializationInfo si;
+        cxxtools::SerializationInfo configSi;
+        configSi.addMember("key") <<= key;
+        configSi.addMember("") <<= loadConfig(mapping, key); // "value" key added inside loadConfig()
+        si.addMember("") <<= configSi;
+        si.setName("config");
+
+        serializer.serialize (si).finish ();
         return HTTP_OK;
     }
 
@@ -185,40 +460,27 @@ UserInfo user;
     ///     POST      //
     ////////////////////
     if (request.isMethodPOST ()) {
-        std::string checked_key;
-        std::string checked_value;
-        std::vector <std::string> checked_values;
-
-        std::map <std::string, zconfig_t*> roots;
         try {
             std::stringstream input (request.getBody (), std::ios_base::in);
             cxxtools::JsonDeserializer deserializer (input);
             cxxtools::SerializationInfo request_doc;
             deserializer.deserialize (request_doc);
-        {
-            std::lock_guard<std::mutex> lock (config_mux);
-            utils::config::json2zpl (roots, request_doc, lock);
 
-            for (const auto &it : roots) {
-                zconfig_t *config = it.second;
-                int rv = zconfig_save (config, it.first.c_str ());
-                if (rv == -1) {
-                    utils::config::roots_destroy (roots);
-                    std::string msg = TRANSLATE_ME ("Cannot save config file ") + it.first;
-                    log_error_audit ("Request CREATE config FAILED");
-                    http_die ("internal-error", msg.c_str ());
-                }
+            if (request_doc.category() != cxxtools::SerializationInfo::Object) {
+                throw std::runtime_error("Request document must be an object.");
             }
-        }   // unlock the guard
+
+            std::lock_guard<std::mutex> lock (config_mux);
+            for (const auto& si : request_doc) {
+                saveConfig(mapping, si.name(), si);
+            }
 </%cpp>
 {}
 <%cpp>
-        utils::config::roots_destroy (roots);
-        log_info_audit ("Request CREATE config SUCCESS");
-        return HTTP_OK;
+            log_info_audit ("Request CREATE config SUCCESS");
+            return HTTP_OK;
         }
         catch (const BiosError &e) {
-            utils::config::roots_destroy (roots);
             log_error_audit ("Request CREATE config FAILED");
             http_die_idx (e.idx, e.what ());
         }


### PR DESCRIPTION
This is a refactoring of the /api/v1/admin/config REST endpoint, allowing the API to store arbitrary JSON objects and removing most hard-coded logic from the endpoint.

Due to unfortunate timing issues, there are a couple of points to address as soon as possible:
* lobby upstream czmq for marking zconfig_remove() as stable
* update 42ity's czmq with upstream's czmq
* remove local zconfig_remove() implementation hack
* split mapping data into separate files inside file-system
* prune dead code

This modification should be backwards-compatible.