### PR TITLE
"No log file" should return HTTP-404

### DIFF
--- a/src/web/src/getlog_GET.ecpp
+++ b/src/web/src/getlog_GET.ecpp
@@ -326,17 +326,18 @@ UserInfo user;
     // e.g. exports from journalctl, so logNAME and logFILE are logically and
     // maybe functionally different beasts below...
 
-    // supported (baseName, filePath) pairs
+    // supported (baseName, filePath, isRealFile) tuples
     struct {
         std::string baseName;
         std::string filePath;
+        bool isRealFile;
     } logsData [] = {
-        { "messages",       "/var/log/messages" },
-        { "www-audit",      "/var/log/tntnet/www-audit.log" },
-        { "mass-mgr-audit", "/var/log/etn-mass-management.audit.log" },
-        { "emc4j-audit",    "/var/log/etn-emc4j-ipm2/karaf.log" },
-        { "journald",       "/tmp/journald.log" }, // gen. by journalctl
-        { "ALL",            "/tmp/getlog_all.tar" }, // archive, all logfiles above
+        { "messages",       "/var/log/messages", true },
+        { "www-audit",      "/var/log/tntnet/www-audit.log", true },
+        { "mass-mgr-audit", "/var/log/etn-mass-management.audit.log", true },
+        { "emc4j-audit",    "/var/log/etn-emc4j-ipm2/karaf.log", true },
+        { "journald",       "/tmp/journald.log", false }, // gen. by journalctl
+        { "ALL",            "/tmp/getlog_all.tar", false }, // archive, all logfiles above
         { "", "" } // term
     };
 
@@ -380,6 +381,7 @@ UserInfo user;
 
         std::string logname_base = slogname_base;
         std::string logname_ext = slogname_ext;
+        bool logname_isRealFile = false; // Return HTTP-404 or HTTP-500 if not found?
 
         // check ext
         if ((logname_ext != "")
@@ -397,6 +399,7 @@ UserInfo user;
         for (int i = 0; !logsData[i].baseName.empty(); ++i) {
             if (logname_base == logsData[i].baseName) {
                 logfile = logsData[i].filePath;
+                logname_isRealFile = logsData[i].isRealFile;
                 break;
             }
         }
@@ -675,7 +678,7 @@ UserInfo user;
         log_error ("%s", message.c_str ());
 
         // TODO: Use (define?) a dedicated exception class; maybe employ bios_throw
-        if ( e.what().find( TRANSLATE_ME ("Could not open requested logfile: ") ) != std::string::npos) {
+        if (logname_isRealFile && e.what().find( TRANSLATE_ME ("Could not open requested logfile: ") ) != std::string::npos) {
             http_die ("not-found", logname_base);
         } else {
             std::string err =  TRANSLATE_ME ("Exception caught. Please check logs for more details.");

--- a/src/web/src/getlog_GET.ecpp
+++ b/src/web/src/getlog_GET.ecpp
@@ -343,6 +343,11 @@ UserInfo user;
 
     std::string message;
 
+    // Parsed, trusted values (if populated)
+    std::string logname_base;
+    std::string logname_ext;
+    bool logname_isRealFile = false; // Return HTTP-404 or HTTP-500 if not found?
+
     try {
         // get args
         std::string slogname_base = request.getArg ("logname_base");
@@ -379,9 +384,8 @@ UserInfo user;
         //ftylog_setVeboseMode(ftylog_getInstance());
         //slogname_base = "ALL"; slogname_ext = ".gz";
 
-        std::string logname_base = slogname_base;
-        std::string logname_ext = slogname_ext;
-        bool logname_isRealFile = false; // Return HTTP-404 or HTTP-500 if not found?
+        logname_base = slogname_base;
+        logname_ext = slogname_ext;
 
         // check ext
         if ((logname_ext != "")

--- a/src/web/src/getlog_GET.ecpp
+++ b/src/web/src/getlog_GET.ecpp
@@ -682,8 +682,8 @@ UserInfo user;
         log_error ("%s", message.c_str ());
 
         // TODO: Use (define?) a dedicated exception class; maybe employ bios_throw
-        if (logname_isRealFile && e.what().find( TRANSLATE_ME ("Could not open requested logfile: ") ) != std::string::npos) {
-            http_die ("not-found", logname_base);
+        if (logname_isRealFile && std::string{e.what()}.find( TRANSLATE_ME ("Could not open requested logfile: ") ) != std::string::npos) {
+            http_die ("not-found", logname_base.c_str());
         } else {
             std::string err =  TRANSLATE_ME ("Exception caught. Please check logs for more details.");
             http_die ("internal-error", err.c_str ());

--- a/src/web/src/getlog_GET.ecpp
+++ b/src/web/src/getlog_GET.ecpp
@@ -548,6 +548,7 @@ UserInfo user;
             std::ifstream in(logfile.c_str());
             if (!in) {
                 if (delete_logfile) remove(logfile.c_str());
+                // This exception string is processed below to return HTTP-404 and not HTTP-500
                 throw std::runtime_error(TRANSLATE_ME ("Could not open requested logfile: ") + logfile);
             }
             std::ostringstream out;
@@ -672,8 +673,14 @@ UserInfo user;
         reply.resetContent();
         message.assign ("Exception caught: ").append (e.what ());
         log_error ("%s", message.c_str ());
-        std::string err =  TRANSLATE_ME ("Exception caught. Please check logs for more details.");
-        http_die( "internal-error", err.c_str ());
+
+        // TODO: Use (define?) a dedicated exception class; maybe employ bios_throw
+        if ( e.what().find( TRANSLATE_ME ("Could not open requested logfile: ") ) != std::string::npos) {
+            http_die ("not-found", logname_base);
+        } else {
+            std::string err =  TRANSLATE_ME ("Exception caught. Please check logs for more details.");
+            http_die ("internal-error", err.c_str ());
+        }
     }
 
 </%cpp>


### PR DESCRIPTION
While updating CI tests for logs, I found that if a log file can not be found on the system (e.g. in a smaller-profile product build) then REST API returns the catch-all HTTP-500 error from this servlet:

````
500 Internal Server Error
    Details:
{
	"errors": [
		{
			"message": { "key": "Internal Server Error. {{var1}}", "variables": { "var1":  { "key": "Exception caught. Please check logs for more details." }  } },
			"debug": "./src/web/src/getlog_GET.ecpp: 676",
			"code": 42
		}
	]
}
````

This PR aims to detect if a valid `logname` was requested, and maps to a "real" file transferred as is, and report a failure to read it as HTTP-404.

This code avoids reporting HTTP-404 for "ALL" (a tarball of other types) and "journald" (exported from systemd), because these are generated and not backed by a particular file, so data missing is truly a server failure creating them. It is expected to return HTTP-404 if it could not read from the original file to serve a compressed variant, as well. If there is a later problem making the compressed stream (e.g. due to low memory or similar issues) a different part of code would throw its exceptions ending up in HTTP-500 as it really would be an Internal Error in that case.

Vague points:
* Maybe we have a suitable exception type to throw for this (currently code used a runtime_error) and so not rely on parsing `e.what()` to check the kind of error as PoCed here
