### PR TITLE
getlog_GET.ecpp : serve the verify-fs log (see fty-core#428)

### DIFF
--- a/src/web/src/getlog_GET.ecpp
+++ b/src/web/src/getlog_GET.ecpp
@@ -333,6 +333,7 @@ UserInfo user;
         bool isRealFile;
     } logsData [] = {
         { "messages",       "/var/log/messages", true },
+        { "verify-fs",      "/var/log/verify-fs.log", true },
         { "www-audit",      "/var/log/tntnet/www-audit.log", true },
         { "mass-mgr-audit", "/var/log/etn-mass-management.audit.log", true },
         { "emc4j-audit",    "/var/log/etn-emc4j-ipm2/karaf.log", true },


### PR DESCRIPTION
The file is introduced by https://github.com/42ity/fty-core/pull/428

TODO: Perhaps test in CI that this call is not invalid (might return empty though)