### PR TITLE
[PQSWPRG-7543] auth_verify.ecpp : pretend user.reauth(true) if session is OK…

### DIFF
--- a/src/web/src/auth_verify.ecpp
+++ b/src/web/src/auth_verify.ecpp
@@ -69,6 +69,13 @@ if(!checked_access_token.empty()) {
         user.gid (gid);
         user.login (user_name);
         delete[] user_name; user_name = NULL;
+
+        // Some of our code expects re-authentication for sensitive requests,
+        // if implemented by a third-party extended authentication module that
+        // would handle auth token processing and verification with higher
+        // priority than this code. In builds using *this* module, default to
+        // pretending the re-auth happened successfully if the session is OK.
+        user.reauth (true);
     } else {
         http_die("not-authorized", "");
     }


### PR DESCRIPTION
… and this lowest-priority auth implem ends up being THE handler

We have code elsewhere (secw, certgen) whose REST API wants sensitive operations re-authenticated every time. However the default auth implementation in fty-rest does not have such a concept and logic; third-party extended user management can provide that. For open-source builds to be usable, short-circuit by default the "user was (re)authenticated" flag during request processing, if the session is valid.

This is a no-op if a higher-priority auth implementation is used in a different bundling of components instead of this file.