### PR TITLE
Add actions by asset REST endpoint

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -101,6 +101,7 @@ EXTRA_DIST += \
     src/web/src/alert_rules_list.h \
     src/web/src/alert_templates.h \
     src/web/src/asset_DELETE.h \
+    src/web/src/actions_GET.h \
     src/web/src/asset_actions_GET.h \
     src/web/src/asset_actions_POST.h \
     src/web/src/asset_export.h \

--- a/project.xml
+++ b/project.xml
@@ -232,6 +232,7 @@
     <class name = "web/src/alert_templates" private = "1" selftest = "0">root object</class>
     <class name = "web/src/asset_DELETE" private = "1" selftest = "0">root object</class>
 
+    <class name = "web/src/actions_GET" private = "1" selftest = "0">root object</class>
     <class name = "web/src/asset_actions_GET" private = "1" selftest = "0">root object</class>
     <class name = "web/src/asset_actions_POST" private = "1" selftest = "0">root object</class>
     <class name = "web/src/asset_export" private = "1" selftest = "0">root object</class>

--- a/src/Makemodule.am
+++ b/src/Makemodule.am
@@ -34,6 +34,7 @@ src_libfty_rest_la_SOURCES = \
     src/web/src/alert_rules_list.cc \
     src/web/src/alert_templates.cc \
     src/web/src/asset_DELETE.cc \
+    src/web/src/actions_GET.cc \
     src/web/src/asset_actions_GET.cc \
     src/web/src/asset_actions_POST.cc \
     src/web/src/asset_export.cc \

--- a/src/fty_rest_classes.h
+++ b/src/fty_rest_classes.h
@@ -117,6 +117,10 @@ typedef struct _web_src_alert_templates_t web_src_alert_templates_t;
 typedef struct _web_src_asset_delete_t web_src_asset_delete_t;
 #define WEB_SRC_ASSET_DELETE_T_DEFINED
 #endif
+#ifndef WEB_SRC_ACTIONS_GET_T_DEFINED
+typedef struct _web_src_actions_get_t web_src_actions_get_t;
+#define WEB_SRC_ACTIONS_GET_T_DEFINED
+#endif
 #ifndef WEB_SRC_ASSET_ACTIONS_GET_T_DEFINED
 typedef struct _web_src_asset_actions_get_t web_src_asset_actions_get_t;
 #define WEB_SRC_ASSET_ACTIONS_GET_T_DEFINED
@@ -343,6 +347,7 @@ typedef struct _web_src_hw_capability_t web_src_hw_capability_t;
 #include "web/src/alert_rules_list.h"
 #include "web/src/alert_templates.h"
 #include "web/src/asset_DELETE.h"
+#include "web/src/actions_GET.h"
 #include "web/src/asset_actions_GET.h"
 #include "web/src/asset_actions_POST.h"
 #include "web/src/asset_export.h"

--- a/src/web/src/actions_GET.ecpp
+++ b/src/web/src/actions_GET.ecpp
@@ -1,0 +1,96 @@
+<#
+ #
+ # Copyright (C) 2015 - 2020 Eaton
+ #
+ # This program is free software; you can redistribute it and/or modify
+ # it under the terms of the GNU General Public License as published by
+ # the Free Software Foundation; either version 2 of the License, or
+ # (at your option) any later version.
+ #
+ # This program is distributed in the hope that it will be useful,
+ # but WITHOUT ANY WARRANTY; without even the implied warranty of
+ # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ # GNU General Public License for more details.
+ #
+ # You should have received a copy of the GNU General Public License along
+ # with this program; if not, write to the Free Software Foundation, Inc.,
+ # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ #
+ #><#
+/*!
+ * \file asset_actions_GET.ecpp
+ * \author Jean-Baptiste Boric <JeanBaptisteBorid@Eaton.com>
+ * \brief Implementation of GET operation for actions on asset
+ */
+ #><%pre>
+#include <cxxtools/regex.h>
+
+#include <fty_proto.h>
+#include <malamute.h>
+
+#include "shared/data.h"
+#include "shared/utils_json.h"
+#include "web/src/asset_computed_impl.h"
+#include <fty_common_rest_helpers.h>
+#include <fty_common_asset_types.h>
+#include <fty_common_dto.h>
+#include <fty_common_mlm.h>
+#include <fty_common_messagebus.h>
+#include <fty_common_mlm_utils.h>
+#include <fty_common_macros.h>
+#include <cxxtools/serializationinfo.h>
+#include <cxxtools/jsonserializer.h>
+</%pre>
+<%request scope="global">
+UserInfo user;
+bool database_ready;
+</%request>
+<%cpp>
+    // verify server is ready
+    if (!database_ready) {
+        log_debug ("Database is not ready yet.");
+        std::string err =  TRANSLATE_ME ("Database is not ready yet, please try again after a while.");
+        http_die ("internal-error", err.c_str ());
+    }
+
+    // check user permissions
+    static const std::map <BiosProfile, std::string> PERMISSIONS = {
+            {BiosProfile::Dashboard, "R"},
+            {BiosProfile::Admin,     "R"}
+            };
+    CHECK_USER_PERMISSIONS_OR_DIE (PERMISSIONS);
+    std::string id = request.getArg("command");
+    if ( id.empty() ) {
+        http_die("request-param-required", "id");
+    }
+
+    auto msgbus = std::unique_ptr<messagebus::MessageBus>(messagebus::MlmMessageBus(MLM_ENDPOINT, messagebus::getClientId("tntnet")));
+    msgbus->connect();
+
+    dto::commands::GetAssetsByCommandQueryDto queryDto;
+    queryDto.command = id;
+
+    messagebus::Message msgRequest;
+    msgRequest.metaData()[messagebus::Message::CORRELATION_ID] = messagebus::generateUuid();
+    msgRequest.metaData()[messagebus::Message::TO] = "fty-nut-command";
+    msgRequest.metaData()[messagebus::Message::SUBJECT] = "GetAssetsByCommand";
+    msgRequest.userData() << queryDto;
+    auto msgReply = msgbus->request("ETN.Q.IPMCORE.POWERACTION", msgRequest, 10);
+
+    if (msgReply.metaData()[messagebus::Message::STATUS] != "ok") {
+        std::string err = "Request to fty-nut-command failed.";
+        log_error (err.c_str ());
+        http_die ("precondition-failed", TRANSLATE_ME (err.c_str ()).c_str ());
+    }
+
+    cxxtools::SerializationInfo replySi;
+    replySi.setCategory(cxxtools::SerializationInfo::Category::Array);
+
+    for (const auto& assetId : msgReply.userData()) {
+        replySi.addMember("") <<= assetId;
+    }
+
+    // Serialize reply.
+    cxxtools::JsonSerializer serializer(reply.out());
+    serializer.serialize(replySi).finish();
+</%cpp>

--- a/src/web/src/actions_GET.h
+++ b/src/web/src/actions_GET.h
@@ -1,0 +1,26 @@
+/*  =========================================================================
+    Copyright (C) 2014 - 2020 Eaton
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+    =========================================================================
+*/
+
+
+#ifndef WEB_SRC_ASSET_ACTIONS_GET_H_INCLUDED
+#define WEB_SRC_ASSET_ACTIONS_GET_H_INCLUDED
+
+
+#endif


### PR DESCRIPTION
Needed for requesting list of assets supporting a particular power action. Note: we need a Swagger workflow inside 42ity to talk to the UI about this.

Depends on 42ity/fty-common-dto#25 to compile, on 42ity/fty-nut#232 to work.