### PR TITLE
src/Makemodule-local.am: use "ecppc -L" to avoid line macros that can…

### DIFF
--- a/src/Makemodule-local.am
+++ b/src/Makemodule-local.am
@@ -141,7 +141,7 @@ package_CLIENTS_BIOS_CSV =    $(DESTDIR)$(bindir)/bios-csv
 ci_helperdir =         $(clientdir)
 
 ECPPC ?= ecppc
-ECPPFLAGS = --nolog
+ECPPFLAGS = --nolog -L
 ECPPFLAGS_CPP = -I$(top_builddir)/include -I$(top_srcdir)/include
 
 ECPPFILES= \


### PR DESCRIPTION
… cause ccache misses

It seems that these line macros embed a path relative to where the tool ran,
and if e.g. in distcheck we run in a .../_build/sub/ as current directory,
these paths starting with ./src/ do not lead anywhere useful (../src/ would).

Checking a theory from recent investigation in our CI farm. If this does end up speeding up the builds, this solution should be cloned to other *-rest components which use `ecppc`.