### PR TITLE
IPMVAL-2889 - fix auth_verify.ecpp : restores behaviour with previous 42ity version

### DIFF
--- a/src/web/src/auth_verify.ecpp
+++ b/src/web/src/auth_verify.ecpp
@@ -97,13 +97,13 @@ std::string gaccess_token;
                     user.reauthDefault (defaultval);
                 } // if reauth flag was not definitely set yet; else don't waste time
             }
-        }
-    }
 
-    // finally die if user is not authenticated
-    if (user.profile() == BiosProfile::Anonymous)
-    {
-        http_die("not-authorized", "");
+            // finally die if access_token is not authenticated
+            if (user.profile() == BiosProfile::Anonymous)
+            {
+                http_die("not-authorized", "");
+            }
+        }
     }
 
 #ifdef DEBUG


### PR DESCRIPTION
* fix: if access_token is empty, continue with Anonymous user profile
  Signed-off-by: Degott, Francois Regis <FrancoisRegisDegott@eaton.com>

**Note: here the api entries supporting Anonymous READ access**
src/web/src/conf_scan.ecpp:264
src/web/src/hw_capability.ecpp:122
src/web/src/info.ecpp:116
src/web/src/license_status.ecpp:41
src/web/src/license_text.ecpp:40
src/web/src/list_gpio.ecpp:167
src/web/src/scan_progress.ecpp:146
src/web/src/sysinfo.ecpp:703
 