### PR TITLE
Fix bad initialization of variable in timegm function and add mutex 

### DIFF
--- a/ecpp/average.ecpp
+++ b/ecpp/average.ecpp
@@ -146,15 +146,17 @@ bool database_ready;
             }
         }
         st = datetime_to_calendar (checked_start_ts.c_str ());
-        if (st == -1) {
-            http_die ("request-param-bad", "start_ts", std::string ("'").append (checked_start_ts).append ("'").c_str (), "format 'YYYYMMDDhhmmssZ");
+        if (st < 0) {
+            http_die ("request-param-bad", "start_ts", std::string ("'").append (checked_start_ts).append ("'").c_str (),
+                std::string ("format 'YYYYMMDDhhmmssZ (Error=").append(std::to_string(st).c_str ()).append (")").c_str ());
         }
         if (checked_end_ts.empty ()) {
             http_die ("request-param-required", "end_ts");
         }
         end = datetime_to_calendar (checked_end_ts.c_str ());
-        if (end == -1) {
-            http_die ("request-param-bad", "end_ts", std::string ("'").append (checked_end_ts).append ("'").c_str (), "format 'YYYYMMDDhhmmssZ");
+        if (end < 0) {
+            http_die ("request-param-bad", "end_ts", std::string ("'").append (checked_end_ts).append ("'").c_str (),
+                std::string ("format 'YYYYMMDDhhmmssZ (Error=").append(std::to_string(st).c_str ()).append (")").c_str ());
         }
 
         // check that start_ts < end_ts

--- a/src/shared/utils.cc
+++ b/src/shared/utils.cc
@@ -22,6 +22,7 @@
 #include "cleanup.h"
 #include <assert.h>
 #include <fty_common.h>
+#include <mutex>
 
 std::mutex timegm_mux;  // Mutex for my_timegm function which is not thread-safe
 

--- a/zproject-hold/tests/shared/test-utils.cc
+++ b/zproject-hold/tests/shared/test-utils.cc
@@ -68,9 +68,9 @@ TEST_CASE ("datetime_to_calendar", "[utils][time]") {
     SECTION ("bad arguments") {
         CHECK ( datetime_to_calendar (NULL) == -1 );
         CHECK ( datetime_to_calendar ("") == -1 );
-        CHECK ( datetime_to_calendar ("20150419181523") == -1 ); // missing utc timezone specifier
-        CHECK ( datetime_to_calendar ("20150419181523z") == -1 ); // wrong small case
-        CHECK ( datetime_to_calendar ("2015041918152Z") == -1 ); // one number short
+        CHECK ( datetime_to_calendar ("20150419181523") == -2 ); // missing utc timezone specifier
+        CHECK ( datetime_to_calendar ("20150419181523z") == -2 ); // wrong small case
+        CHECK ( datetime_to_calendar ("2015041918152Z") == -2 ); // one number short
     }
     SECTION ("correct execution") {
         CHECK ( datetime_to_calendar ("20150301100532Z") == 1425204332 );


### PR DESCRIPTION
NOTE: TESTS DESACTIVATED FOR THIS PART. UNIT TESTS HAVE BEING DESACTIVATED DURING CMAKE MIGRATION ???