### PR TITLE
[IPMPROG-2701] ecpp/license_POST.ecpp: let start-db-services run…

### DIFF
--- a/ecpp/license_POST.ecpp
+++ b/ecpp/license_POST.ecpp
@@ -164,146 +164,158 @@ bool database_ready;
         // the wait() would end earlier if the child process finishes:
         int wait_cycle = 3 * 60000;
 
-        // configured in seconds
+        // configured in seconds, waiting in milliseconds:
         unsigned int mrt = tnt::TntConfig::it().maxRequestTime;
         if (mrt > 0 && mrt < (INT_MAX / 1000)) { // if enabled at all
             wait_cycle = static_cast<int>(mrt) * 666 ; // convert to msec and trim 2/3 for overheads
         }
         log_debug ("Starting db service will refresh tntnet deadman timer every %u msec", wait_cycle);
 
-repeat_start_db_services:
-        auto rv_svc = proc.wait(wait_cycle);
-        if (!rv_svc && "timeout" == rv_svc.error()) {
-            // Alas, "Expected" class deletes the assignment etc. operators,
-            // so we can not stash a value or change a variable, and have to
-            // loop old-school way with goto...
+        for (;;) { // repeat_start_db_services:
+            // May finish before "wait_cycle" elapses:
+            auto rv_svc = proc.wait(wait_cycle);
             uint64_t tme_finish = uint64_t(::time (NULL));
-            log_info ("Starting db service takes longer than expected on this system, waiting more, timestamp=%" PRIu64 " (duration=%" PRIu64 ")" ,
-                tme_finish, (tme_finish - tme_start));
-            request.touch();
-            goto repeat_start_db_services;
-        }
-        proc_out = proc.readAllStandardOutput();
-        proc_err = proc.readAllStandardError();
-        proc.kill();
 
-        uint64_t tme_finish = uint64_t(::time (NULL));
-        if (rv_svc) {
-            log_info ("Starting db service completed, timestamp=%" PRIu64 " (duration=%" PRIu64 "), exit-code=%i ..." ,
-                tme_finish, (tme_finish - tme_start), *rv_svc);
-        } else {
-            log_info ("Starting db service completed, timestamp=%" PRIu64 " (duration=%" PRIu64 "), exit-code=%s ..." ,
-                tme_finish, (tme_finish - tme_start), rv_svc.error().c_str());
-        }
-        if (!rv_svc || *rv_svc != 0) {
-            log_error ("Starting of start-db-services have failed. Consult system logs");
-            log_error ("%s failed with error %s.\n===== STDOUT: =====\n%s\n===== STDERR: =====\n%s\n=====",
-                "/usr/libexec/fty/start-db-services", rv_svc.error().c_str(), proc_out.c_str (), proc_err.c_str ());
-
-            if (rv_svc.error() != "timeout") {
-                std::string err =  TRANSLATE_ME ("Starting of start-db-services have failed. Consult system logs");
-                log_error_audit ("Request CREATE license FAILED");
-                http_die ("internal-error", err.c_str ());
-            }
-            // Negative return means killed by signal, typically by our
-            // subprocess timeout handling - fall through to try using DB
-
-            {
-                std::string proc_out1, proc_err1;
-                int lastResult = 0;
-                for (int i = 0; i < 10; ++i) {
-                    fty::Process::Arguments proc_cmd = {"systemctl", "list-ipm-units", "--active", "fty-db-engine"};
-                    // This should get our "systemctl" wrapper via PATH
-
-                    auto rv = fty::Process::run("sudo", proc_cmd, proc_out1, proc_err1);
-
-                    if (!rv) {
-                        log_error(rv.error().c_str());
-                        log_error_audit ("Request CREATE license FAILED");
-                        http_die ("internal-error", TRANSLATE_ME ("Database software service is not running").c_str());
-                    }
-
-                    lastResult = *rv;
-                    if (*rv == 0) {
-                        break;
-                    }
-                    sleep(5);
-                }
-
-                if (lastResult != 0) {
-                    std::string message;
-                    message = "`sudo systemctl list-ipm-units --active fty-db-engine`"
-                        " failed (service is not currently active). Return value = '"
-                        + std::to_string (lastResult) + "', stderr = '" + proc_err1 + "'." ;
-                    log_error ("%s", message.c_str ());
-                    std::string err =  TRANSLATE_ME ("Database software service is not running");
-                    log_error_audit ("Request CREATE license FAILED");
-                    http_die ("internal-error", err.c_str ());
-                } else {
-                    // Not quite an error, but we want this message at the same logging level
-                    log_error ("NOTE: Although start-db-services script was killed, the fty-db-engine service is okay");
-                }
+            // Success? Fail? Keep waiting?..
+            if (!rv_svc && "timeout" == rv_svc.error()) {
+                // ...keep waiting, script is not finished:
+                log_info ("Starting db service takes longer than expected on this system, waiting more, timestamp=%" PRIu64 " (duration=%" PRIu64 ")" ,
+                    tme_finish, (tme_finish - tme_start));
+                request.touch();
+                continue; // goto repeat_start_db_services;
             }
 
+            // ...success or fail, script is finished
+            // Read the outputs:
+            proc_out = proc.readAllStandardOutput();
+            proc_err = proc.readAllStandardError();
+            // Terminate child (if any) to avoid leaks:
+            proc.kill();
 
-            {
-                std::string proc_out1, proc_err1;
-                int lastResult = 0;
-
-                // try to increase timeout..
-                for (int i = 0; i < 50; ++i) {
-                    fty::Process::Arguments proc_cmd {"systemctl", "list-ipm-units", "--active", "fty-db-init"};
-                    // This should get our "systemctl" wrapper via PATH
-
-                    auto rv = fty::Process::run("sudo", proc_cmd, proc_out1, proc_err1);
-
-                    if (!rv) {
-                        log_error(rv.error().c_str());
-                        log_error_audit("--! %s", rv.error().c_str());
-                        log_error_audit ("Request CREATE license FAILED");
-                        http_die ("internal-error", TRANSLATE_ME ("Database schema was not installed or verified successfully").c_str());
-                    }
-
-                    lastResult = *rv;
-                    if (*rv == 0) {
-                        log_error_audit("is ok");
-                        break;
-                    }
-                    log_error_audit("next to check");
-                    sleep(5);
-                }
-
-                if (lastResult != 0) {
-                    std::string message = "`sudo systemctl list-ipm-units --active fty-db-init`"
-                        " failed (service is not currently active). Return value = '"
-                        + std::to_string (lastResult) + "', stderr = '" + proc_err1 + "'." ;
-                    log_error ("%s", message.c_str());
-                    log_error_audit("%s", message.c_str());
-                    std::string err =  TRANSLATE_ME ("Database schema was not installed or verified successfully");
-                    log_error_audit ("Request CREATE license FAILED");
-                    http_die ("internal-error", err.c_str ());
-                } else {
-                    // Not quite an error, but we want this message at the same logging level
-                    log_error ("NOTE: Although start-db-services script was killed, the fty-db-init service is okay");
-                }
-            }
-        }
-
-        // once done, check environment files for accessing the database
-        uint64_t tme_started = uint64_t(::time (NULL));
-        log_info ("db services were started by timestamp=%" PRIu64 ", re-reading password ...", tme_started);
-        int rv_dbcred = DBConn::dbreadcredentials ();
-        if (!rv_dbcred) {
-            std::string message;
-            if (*rv_svc != 0) {
-                message = TRANSLATE_ME ("Database password file is missing AND failed to start start-db-services. Consult system logs");
+            if (rv_svc) {
+                log_info ("Starting db service completed, timestamp=%" PRIu64 " (duration=%" PRIu64 "), exit-code=%i ..." ,
+                    tme_finish, (tme_finish - tme_start), *rv_svc);
             } else {
-                message = TRANSLATE_ME ("Database password file is missing");
+                log_info ("Starting db service completed, timestamp=%" PRIu64 " (duration=%" PRIu64 "), exit-code=%s ..." ,
+                    tme_finish, (tme_finish - tme_start), rv_svc.error().c_str());
             }
-            log_error ("%s", message.c_str ());
-            log_error_audit ("Request CREATE license FAILED");
-            http_die ("internal-error", message.c_str ());
-        }
+
+            // non-zero exit code or proc class exception:
+            if (!rv_svc || *rv_svc != 0) {
+                log_error ("Starting of start-db-services have failed. Consult system logs");
+                log_error ("%s failed with error %s.\n===== STDOUT: =====\n%s\n===== STDERR: =====\n%s\n=====",
+                    "/usr/libexec/fty/start-db-services", rv_svc.error().c_str(), proc_out.c_str (), proc_err.c_str ());
+
+                if (rv_svc.error() != "timeout") {
+                    std::string err =  TRANSLATE_ME ("Starting of start-db-services have failed. Consult system logs");
+                    log_error_audit ("Request CREATE license FAILED");
+                    http_die ("internal-error", err.c_str ());
+                }
+                // Negative return means killed by signal, typically by our
+                // subprocess timeout handling - fall through to try using DB
+
+                { // scoping for error-handling: inspect fty-db-engine (mysqld etc) service unit status:
+                    std::string proc_out1, proc_err1;
+                    int lastResult = 0;
+                    for (int i = 0; i < 10; ++i) {
+                        fty::Process::Arguments proc_cmd = {"systemctl", "list-ipm-units", "--active", "fty-db-engine"};
+                        // This should get our "systemctl" wrapper via PATH
+
+                        auto rv = fty::Process::run("sudo", proc_cmd, proc_out1, proc_err1);
+
+                        if (!rv) {
+                            log_error(rv.error().c_str());
+                            log_error_audit ("Request CREATE license FAILED");
+                            http_die ("internal-error", TRANSLATE_ME ("Database software service is not running").c_str());
+                        }
+
+                        lastResult = *rv;
+                        if (*rv == 0) {
+                            break;
+                        }
+                        sleep(5);
+                    }
+
+                    if (lastResult != 0) {
+                        std::string message;
+                        message = "`sudo systemctl list-ipm-units --active fty-db-engine`"
+                            " failed (service is not currently active). Return value = '"
+                            + std::to_string (lastResult) + "', stderr = '" + proc_err1 + "'." ;
+                        log_error ("%s", message.c_str ());
+                        std::string err =  TRANSLATE_ME ("Database software service is not running");
+                        log_error_audit ("Request CREATE license FAILED");
+                        http_die ("internal-error", err.c_str ());
+                    } else {
+                        // Not quite an error, but we want this message at the same logging level
+                        log_error ("NOTE: Although start-db-services script was killed, the fty-db-engine service is okay");
+                    }
+                }
+
+
+                { // scoping for error-handling: inspect fty-db-init (schema import) service unit status:
+                    std::string proc_out1, proc_err1;
+                    int lastResult = 0;
+
+                    // try to increase timeout..
+                    for (int i = 0; i < 50; ++i) {
+                        fty::Process::Arguments proc_cmd {"systemctl", "list-ipm-units", "--active", "fty-db-init"};
+                        // This should get our "systemctl" wrapper via PATH
+
+                        auto rv = fty::Process::run("sudo", proc_cmd, proc_out1, proc_err1);
+
+                        if (!rv) {
+                            log_error(rv.error().c_str());
+                            log_error_audit("--! %s", rv.error().c_str());
+                            log_error_audit ("Request CREATE license FAILED");
+                            http_die ("internal-error", TRANSLATE_ME ("Database schema was not installed or verified successfully").c_str());
+                        }
+
+                        lastResult = *rv;
+                        if (*rv == 0) {
+                            log_error_audit("is ok");
+                            break;
+                        }
+                        log_error_audit("next to check");
+                        sleep(5);
+                    }
+
+                    if (lastResult != 0) {
+                        std::string message = "`sudo systemctl list-ipm-units --active fty-db-init`"
+                            " failed (service is not currently active). Return value = '"
+                            + std::to_string (lastResult) + "', stderr = '" + proc_err1 + "'." ;
+                        log_error ("%s", message.c_str());
+                        log_error_audit("%s", message.c_str());
+                        std::string err =  TRANSLATE_ME ("Database schema was not installed or verified successfully");
+                        log_error_audit ("Request CREATE license FAILED");
+                        http_die ("internal-error", err.c_str ());
+                    } else {
+                        // Not quite an error, but we want this message at the same logging level
+                        log_error ("NOTE: Although start-db-services script was killed, the fty-db-init service is okay");
+                    }
+                }
+            } // handle if script failed
+
+            // once done, check environment files for accessing the database
+            uint64_t tme_started = uint64_t(::time (NULL));
+            log_info ("db services were started by timestamp=%" PRIu64 ", re-reading password ...", tme_started);
+            int rv_dbcred = DBConn::dbreadcredentials ();
+            if (!rv_dbcred) {
+                std::string message;
+                if (*rv_svc != 0) {
+                    message = TRANSLATE_ME ("Database password file is missing AND failed to start start-db-services. Consult system logs");
+                } else {
+                    message = TRANSLATE_ME ("Database password file is missing");
+                }
+                log_error ("%s", message.c_str ());
+                log_error_audit ("Request CREATE license FAILED");
+                http_die ("internal-error", message.c_str ());
+            }
+
+            // we get here when script completed (well or not),
+            // so finish the infinite loop:
+            break;
+        } // for deadman timer around start-db-services
+
     } else {
         // enforce reload of credentials, e.g. if timely service startup
         // had failed previously but the system has caught up by now

--- a/ecpp/license_POST.ecpp
+++ b/ecpp/license_POST.ecpp
@@ -203,6 +203,7 @@ bool database_ready;
             }
 
             // ...success or fail, script is finished
+            log_info ("Starting db service helper script has finished, collecting results");
 
             // Read all of the buffers; note that fty-utils defaults the args
             // for readFromFd() behind these methods in a way that it would

--- a/ecpp/license_POST.ecpp
+++ b/ecpp/license_POST.ecpp
@@ -207,11 +207,20 @@ bool database_ready;
 
             // non-zero exit code or proc class exception:
             if (!rv_svc || *rv_svc != 0) {
+                std::string rv_svc_err;
+                if (rv_svc) {
+                    rv_svc_err = "code ";
+                    rv_svc_err += std::to_string(*rv_svc);
+                } else {
+                    rv_svc_err = rv_svc.error();
+                }
+
                 log_error ("Starting of start-db-services have failed. Consult system logs");
                 log_error ("%s failed with error %s.\n===== STDOUT: =====\n%s\n===== STDERR: =====\n%s\n=====",
-                    "/usr/libexec/fty/start-db-services", rv_svc.error().c_str(), proc_out.c_str (), proc_err.c_str ());
+                    "/usr/libexec/fty/start-db-services",
+                    rv_svc_err.c_str(), proc_out.c_str(), proc_err.c_str());
 
-                if (rv_svc.error() != "timeout") {
+                if (!rv_svc && rv_svc.error() != "timeout") {
                     std::string err =  TRANSLATE_ME ("Starting of start-db-services have failed. Consult system logs");
                     log_error_audit ("Request CREATE license FAILED");
                     http_die ("internal-error", err.c_str ());

--- a/ecpp/license_POST.ecpp
+++ b/ecpp/license_POST.ecpp
@@ -177,6 +177,18 @@ bool database_ready;
         log_debug ("Starting db service will refresh tntnet deadman timer every %u msec", wait_cycle);
 
         for (;;) { // repeat_start_db_services:
+            // Read the outputs (continuously, to avoid script blocking
+            // on write() here; repeated below for endspiel):
+            while (true) {
+                std::string strerr = proc.readAllStandardError();
+                std::string strout = proc.readAllStandardOutput();
+                if (strerr.empty() && strout.empty()) {
+                    break;
+                }
+                if (!strerr.empty()) proc_err += strerr;
+                if (!strout.empty()) proc_out += strout;
+            }
+
             // May finish before "wait_cycle" elapses:
             auto rv_svc = proc.wait(wait_cycle);
             uint64_t tme_finish = uint64_t(::time (NULL));
@@ -191,9 +203,22 @@ bool database_ready;
             }
 
             // ...success or fail, script is finished
-            // Read the outputs:
-            proc_out = proc.readAllStandardOutput();
-            proc_err = proc.readAllStandardError();
+
+            // Read all of the buffers; note that fty-utils defaults the args
+            // for readFromFd() behind these methods in a way that it would
+            // only try twice. So much for "all" in the name. Loop until dry
+            // (otherwise after some traffic the script effectively blocks
+            // when it is not milked away):
+            while (true) {
+                std::string strerr = proc.readAllStandardError();
+                std::string strout = proc.readAllStandardOutput();
+                if (strerr.empty() && strout.empty()) {
+                    break;
+                }
+                if (!strerr.empty()) proc_err += strerr;
+                if (!strout.empty()) proc_out += strout;
+            }
+
             // Terminate child (if any) to avoid leaks:
             proc.kill();
 

--- a/ecpp/license_POST.ecpp
+++ b/ecpp/license_POST.ecpp
@@ -180,8 +180,8 @@ bool database_ready;
             // Read the outputs (continuously, to avoid script blocking
             // on write() here; repeated below for endspiel):
             while (true) {
-                std::string strerr = proc.readAllStandardError();
-                std::string strout = proc.readAllStandardOutput();
+                std::string strerr = proc.readAllStandardError(100);
+                std::string strout = proc.readAllStandardOutput(100);
                 if (strerr.empty() && strout.empty()) {
                     break;
                 }
@@ -211,8 +211,8 @@ bool database_ready;
             // (otherwise after some traffic the script effectively blocks
             // when it is not milked away):
             while (true) {
-                std::string strerr = proc.readAllStandardError();
-                std::string strout = proc.readAllStandardOutput();
+                std::string strerr = proc.readAllStandardError(100);
+                std::string strout = proc.readAllStandardOutput(100);
                 if (strerr.empty() && strout.empty()) {
                     break;
                 }

--- a/ecpp/license_POST.ecpp
+++ b/ecpp/license_POST.ecpp
@@ -167,13 +167,22 @@ bool database_ready;
         // (child still running as of last check before time limit; no other
         // errors) as per fty-utils::fty/process.h wording of Process::wait().
         // the wait() would end earlier if the child process finishes:
-        int wait_cycle = 3 * 60000;
+
+        // Use shorter loops to avoid long wait if script is stuck flushing
+        // its output:
+        int wait_cycle = 5000;
+
+#if 0
+        // Override to longer waits... at a risk of longer unblocking of
+        // stuck write() calls in child process:
+        wait_cycle = 3 * 60000;
 
         // configured in seconds, waiting in milliseconds:
         unsigned int mrt = tnt::TntConfig::it().maxRequestTime;
         if (mrt > 0 && mrt < (INT_MAX / 1000)) { // if enabled at all
             wait_cycle = static_cast<int>(mrt) * 666 ; // convert to msec and trim 2/3 for overheads
         }
+#endif
         log_debug ("Starting db service will refresh tntnet deadman timer every %u msec", wait_cycle);
 
         for (;;) { // repeat_start_db_services:

--- a/ecpp/license_POST.ecpp
+++ b/ecpp/license_POST.ecpp
@@ -132,12 +132,17 @@ bool database_ready;
         log_info ("Starting db service, timestamp=%" PRIu64 " ..." , tme_start);
         std::string proc_out, proc_err;
 
+        // Just a short sleep first: hopefully systemd would already
+        // pick up the appearance of touch-file and begin handling FLA:
         sleep(10);
 
         // due to some OS circumstances, the script can sometimes block
         // while calling the /bin/systemctl and is eventually killed,
         // even though the actual services of our product have started
-        // long before this; so even if it failed - try to use the DB...
+        // long before this; so even if it failed - we would try to use
+        // the DB opportunistically... Still, better to know we have
+        // all the backend services running that are needed for EULA
+        // wizard and beyond!
         fty::Process proc("/usr/libexec/fty/start-db-services", {}, fty::Capture::Out | fty::Capture::Err);
         if (auto ret = proc.run(); !ret) {
             log_error("Starting of start-db-services have failed. Consult system logs");

--- a/ecpp/license_POST.ecpp
+++ b/ecpp/license_POST.ecpp
@@ -31,7 +31,9 @@
 #include <fstream>
 #include <string.h>
 #include <stdlib.h>
+#include <stdint.h>
 #include <tntdb.h>
+#include <tnt/tntconfig.h>
 
 #include "shared/utils.h"
 #include "cleanup.h"
@@ -142,7 +144,45 @@ bool database_ready;
             log_error(ret.error().c_str());
             http_die("internal-error", ret.error().c_str());
         }
-        auto rv_svc = proc.wait(15000);
+
+        // The start-db-services script ensures that all FTY/IPM2 related
+        // services and targets become active, including that the database
+        // schema gets initialized and its chain of consumers starts,
+        // and we are blocked until we "know" there is now someone running
+        // that would actually handle the backend requests for the rest of
+        // EULA wizard.
+        // So as far as we are concerned here, the script runtime can last
+        // several minutes (even if the CPU/IO/Time load is mostly elsewhere).
+        // Normally tntnet would suicide with a 10-minute request processing,
+        // unless a deadman timer is tickled to confirm we are stoll alive.
+        // This can be tuned with maxRequestTime (0 to disable the watchdog)
+        // or handled safely with a loop sleeping, checking that the script
+        // still runs, and tickling tntnet::Worker::touch() in the known-long
+        // processing loop. It should suffice to catch `unexpected("timeout")`
+        // (child still running as of last check before time limit; no other
+        // errors) as per fty-utils::fty/process.h wording of Process::wait().
+        // the wait() would end earlier if the child process finishes:
+        int wait_cycle = 3 * 60000;
+
+        // configured in seconds
+        unsigned int mrt = tnt::TntConfig::it().maxRequestTime;
+        if (mrt > 0 && mrt < (INT_MAX / 1000)) { // if enabled at all
+            wait_cycle = static_cast<int>(mrt) * 666 ; // convert to msec and trim 2/3 for overheads
+        }
+        log_debug ("Starting db service will refresh tntnet deadman timer every %u msec", wait_cycle);
+
+repeat_start_db_services:
+        auto rv_svc = proc.wait(wait_cycle);
+        if (!rv_svc && "timeout" == rv_svc.error()) {
+            // Alas, "Expected" class deletes the assignment etc. operators,
+            // so we can not stash a value or change a variable, and have to
+            // loop old-school way with goto...
+            uint64_t tme_finish = uint64_t(::time (NULL));
+            log_info ("Starting db service takes longer than expected on this system, waiting more, timestamp=%" PRIu64 " (duration=%" PRIu64 ")" ,
+                tme_finish, (tme_finish - tme_start));
+            request.touch();
+            goto repeat_start_db_services;
+        }
         proc_out = proc.readAllStandardOutput();
         proc_err = proc.readAllStandardError();
         proc.kill();


### PR DESCRIPTION
…as long as it needs to ensure EULA wizard is handled well

Currently the script is aborted soon after start (due to 15 sec wait and then kill) while the db-init and other backend services take much longer to complete the start-up and to handle the rest of EULA wizard and other activities (approx 90 sec in local-VM testing; generally depends on hypervisor and its storage congestion vs. peak performance).

Notably, the early abort of the script by tntnet precludes starting the "ipm2-target-watchdog" after all those initializations, so the system does not recover if some units fail later (they stop and restart, but units who depended on them stop and have no cause to start... watchdog timers try to ensure they do so at least at some point; in newer systemd we could use Upholds=... for better effect).